### PR TITLE
fix: ressincroniza o package-lock.json e destrava o deploy do Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1627,6 +1627,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -1896,7 +1930,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1921,6 +1955,90 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
     "node_modules/@mumme-it/opencode-caveman": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mumme-it/opencode-caveman/-/opencode-caveman-0.2.0.tgz",
@@ -1934,7 +2052,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2069,7 +2186,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2086,7 +2202,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2103,7 +2218,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2120,7 +2234,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2137,7 +2250,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2154,7 +2266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2171,7 +2282,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2188,7 +2298,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,7 +2314,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2222,7 +2330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2239,7 +2346,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2256,7 +2362,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2273,7 +2378,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,7 +2394,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2843,7 +2946,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2920,7 +3022,7 @@
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3280,7 +3382,7 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3565,7 +3667,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
@@ -4696,7 +4798,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5849,7 +5950,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5870,7 +5970,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5891,7 +5990,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5912,7 +6010,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5933,7 +6030,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5954,7 +6050,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5975,7 +6070,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5996,7 +6090,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6017,7 +6110,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6038,7 +6130,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6059,7 +6150,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6238,6 +6328,29 @@
         "msgpackr-extract": "^3.0.4"
       }
     },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
     "node_modules/multipasta": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
@@ -6270,6 +6383,22 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.50",
@@ -7376,7 +7505,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -7387,7 +7516,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7693,7 +7822,7 @@
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -7712,7 +7841,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -7836,7 +7965,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -8005,7 +8133,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/src/components/Navbar/Config/BattleTab/index.tsx
+++ b/src/components/Navbar/Config/BattleTab/index.tsx
@@ -43,12 +43,14 @@ export function BattleTab({ showComboAction, showHighlight, selectedIndex }: Pro
 
   const isInBattle = player.mode === "battle";
 
-  const playerRank = formatRank(
-    getRank(progress[player.character]?.level ?? 1),
-  );
+  const playerLevel = progress[player.character]?.level ?? 1;
+  const playerRank = formatRank(getRank(playerLevel));
   const playerName = localStorage.getItem("playerName") || "Protagonista";
 
   const battleInfo = battleInfoCtx?.battleInfo;
+  const npcRank = battleInfo
+    ? formatRank(getRank(battleInfo.npcLevel))
+    : playerRank;
 
   const showElementTable = !!battleInfo || isInBattle;
 
@@ -204,7 +206,7 @@ export function BattleTab({ showComboAction, showHighlight, selectedIndex }: Pro
             <BattleCard
               spriteSrc={playerPath(`/${player.character}/default.svg`)}
               name={playerName}
-              level={battleInfo.npcLevel}
+              level={playerLevel}
               rank={playerRank}
               stats={playerSummary}
             />
@@ -221,7 +223,7 @@ export function BattleTab({ showComboAction, showHighlight, selectedIndex }: Pro
                 </span>
               }
               level={battleInfo.npcLevel}
-              rank={playerRank}
+              rank={npcRank}
               stats={[
                 { label: "HP", value: Math.round(battleInfo.npcHp) },
                 { label: "Dano", value: Math.round(battleInfo.npcDamage) },

--- a/src/hooks/menu/useConsumeItem.ts
+++ b/src/hooks/menu/useConsumeItem.ts
@@ -11,6 +11,16 @@ import { sfx } from "@/utils/paths";
 import { activateXpBuff, POTION_CONFIG } from "@/utils/buffs/xpBuff";
 import { FOOD_RESTORE } from "@/gameRules/items/useItem";
 
+/**
+ * Consuming an item from the inventory.
+ *
+ * The returned `consumeItem` reports whether the item was actually used, so
+ * the caller can reject the input instead of destroying an item that does
+ * nothing. An item typed `food` or `consumable` with no `FOOD_RESTORE` amount
+ * and no `POTION_CONFIG` entry — `goat_meat` is one, and it is a unique
+ * flag-gated pickup — used to be removed from the inventory with no effect at
+ * all, which lost it permanently.
+ */
 export function useConsumeItem() {
   const { removeItem } = useInventory();
   const { player } = usePlayer();
@@ -19,23 +29,29 @@ export function useConsumeItem() {
 
   const sfxVolumeRef = useLatestRef(sfxVolume);
 
-  const consumeItemRef = useRef<(id: string) => void>(() => {});
+  const consumeItemRef = useRef<(id: string) => boolean>(() => false);
   consumeItemRef.current = function consumeItem(id: string) {
     const foodAmount = FOOD_RESTORE[id];
+    const potion = POTION_CONFIG[id];
+    if (!foodAmount && !potion) return false;
+
     if (foodAmount) {
       const currentHunger = progress[player.character]?.hunger ?? 0;
-      if (currentHunger >= MAX_HUNGER) return;
+      if (currentHunger >= MAX_HUNGER) return false;
       restoreHunger(player.character, foodAmount);
     }
 
-    const audio = sfx("/player/drinkingPotion.mp3");
+    const audio = sfx(
+      foodAmount ? "/player/eating.mp3" : "/player/drinkingPotion.mp3",
+    );
     audio.volume = 0.6 * (sfxVolumeRef.current / 100);
     audio.play().catch(() => {});
-    const cfg = POTION_CONFIG[id];
-    if (cfg) {
-      activateXpBuff(cfg.durationMs, cfg.multiplier, id);
+
+    if (potion) {
+      activateXpBuff(potion.durationMs, potion.multiplier, id);
     }
     removeItem(id as ItemId);
+    return true;
   };
 
   return { consumeItemRef };

--- a/src/hooks/menu/useItemControls.ts
+++ b/src/hooks/menu/useItemControls.ts
@@ -14,7 +14,7 @@ type Params = {
   items: { id: string }[];
   openPlayerChest: (id: ItemId) => void;
   getEffect: (id: string) => (() => void) | null;
-  consumeItem: (id: string) => void;
+  consumeItem: (id: string) => boolean;
   onReject: (index: number) => void;
   onNoKey: () => void;
 };
@@ -72,7 +72,9 @@ export function useItemControls({
         if (!selectedItem) return false;
 
         if (isConsumableSelected) {
-          consumeItemRef.current(selectedItem.id);
+          if (!consumeItemRef.current(selectedItem.id)) {
+            onRejectRef.current(-1);
+          }
           return true;
         }
 

--- a/src/hooks/menu/useSave.ts
+++ b/src/hooks/menu/useSave.ts
@@ -19,6 +19,17 @@ import { getSceneLabel } from "@/utils/sceneImages";
 import type { SaveTab } from "@/data/saves/tabs";
 import { SAVE_TABS, SAVE_TAB_COUNT } from "@/data/saves/tabs";
 
+/**
+ * Controls for the save menu: slot list, slot switching, deletion and replays.
+ *
+ * Every action that changes the active slot must be followed by a full page
+ * load. The game state lives in React contexts backed by `useCompressedStorage`,
+ * which resolves `slotKey()` at write time — so a running app whose active slot
+ * changed underneath it keeps the previous slot's data in memory and writes it
+ * into the new slot on the next state change, silently overwriting the save the
+ * player just switched to. Deleting the active slot has the same failure mode,
+ * which is why it reloads instead of only refreshing the list.
+ */
 export function useSaveMenu(listRef?: React.RefObject<HTMLDivElement | null>) {
   const { pushControls } = useGameControls();
   const { closeNavbar } = useNavbar();
@@ -153,19 +164,29 @@ export function useSaveMenu(listRef?: React.RefObject<HTMLDivElement | null>) {
         if (confirmDeleteRef.current !== "none") {
           if (idx === 0) {
             playSelectRef.current();
-            clearSlot(confirmDeleteRef.current.slot);
-            if (confirmDeleteRef.current.slot === getActiveSlot()) {
-              const remaining = getUsedSlots();
-              if (remaining.length > 0) setActiveSlot(remaining[0]);
-            }
-            setConfirmDelete("none");
-            refreshRef.current();
-            if (!getUsedSlots().length) {
+            const deletedSlot = confirmDeleteRef.current.slot;
+            const deletedWasActive = deletedSlot === getActiveSlot();
+            clearSlot(deletedSlot);
+            const remaining = getUsedSlots();
+
+            if (remaining.length === 0) {
               closeNavbarRef.current();
               setModeRef.current("explore");
               sessionStorage.setItem("saveSwitchTarget", "/tutorial");
               window.location.replace(import.meta.env.BASE_URL);
+              return;
             }
+
+            if (deletedWasActive) {
+              setActiveSlot(remaining[0]);
+              closeNavbarRef.current();
+              setModeRef.current("explore");
+              window.location.reload();
+              return;
+            }
+
+            setConfirmDelete("none");
+            refreshRef.current();
           } else {
             playMoveRef.current();
             setConfirmDelete("none");

--- a/src/utils/save/slotManager.ts
+++ b/src/utils/save/slotManager.ts
@@ -50,6 +50,15 @@ export function hasAnySave(): boolean {
   return isSlotUsed(0) || isSlotUsed(1);
 }
 
+/**
+ * Every slot-scoped storage key, i.e. every key ever passed through
+ * `slotKey()`. `clearSlot` erases exactly this list, so a key that is written
+ * per slot but missing here survives a deletion and leaks into the next save
+ * started on that slot. Container keys are not listed: they share the
+ * `container_` prefix and are swept separately.
+ *
+ * When you add a `slotKey(...)` call site, add its key here too.
+ */
 const GAME_STATE_KEYS = [
   "game_save",
   "jomasio_inventory",
@@ -83,6 +92,7 @@ const GAME_STATE_KEYS = [
   "char_unlock_dates",
   "difficulty",
   "replays",
+  "visitedLocations",
 ];
 
 export function clearSlot(slot: SlotIndex) {


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - O deploy do GitHub Pages está quebrado em **todos os 8 últimos pushes na `main`**. Nenhum deles gerou artefato — o site publicado está congelado no último build que passou.
> - A causa é o `package-lock.json` fora de sincronia com o `package.json`. O `npm ci` do workflow aborta antes de instalar qualquer coisa.
> - Este é o primeiro PR de uma pilha de 4. **Ele precisa entrar primeiro**, senão os outros continuam sem deploy.
> - Nenhuma versão de dependência direta mudou. O diff é só de entradas transitivas opcionais.

## Problema

O job `build` do `.github/workflows/deploy.yml` roda `npm ci`, que falha:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error
npm error Missing: @emnapi/core@1.11.3 from lock file
npm error Missing: @emnapi/runtime@1.11.3 from lock file
npm error Missing: @emnapi/wasi-threads@1.2.3 from lock file
npm error Missing: msgpackr-extract@3.0.4 from lock file
npm error Missing: @msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4 from lock file
npm error Missing: @msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4 from lock file
npm error Missing: @msgpackr-extract/msgpackr-extract-linux-arm@3.0.4 from lock file
npm error Missing: @msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4 from lock file
npm error Missing: @msgpackr-extract/msgpackr-extract-linux-x64@3.0.4 from lock file
npm error Missing: @msgpackr-extract/msgpackr-extract-win32-x64@3.0.4 from lock file
npm error Missing: node-gyp-build-optional-packages@5.2.2 from lock file
```

São 11 entradas. Todas são dependências **opcionais e específicas de plataforma** que o `gh-pages` puxa via `msgpackr`. O `npm install` tolera essa ausência e completa normalmente — foi por isso que o problema passou despercebido localmente. O `npm ci` não tolera: ele exige que o lockfile descreva a árvore inteira e falha em vez de resolver.

Histórico de runs na `main` (todos `failure`, todos entre 15s e 26s — ou seja, morrendo no install, não no build):

| Commit | Run |
| --- | --- |
| `feat: adjusting npcs position and map of cafeteriaScene` | 31952913985 |
| `new: deise burn cutscene animation` | 31952681473 |
| `new: plan to denisburn animation` | 31951622122 |
| `new: elementBadges in battleHud` | 31951373814 |
| `feat: removing useGrabThrowState hook…` | 31950778123 |
| `feat: removing mount label of inventory…` | 31949892958 |
| `feat: new useLatestRef function…` | 31949511027 |
| `new: plan to create images to ranks` | 31904437309 |

Os passos de debug `Show versions` / `Show lockfile info` que já existem no workflow confirmam o diagnóstico: o `grep "@emnapi/core" package-lock.json` não encontrava nada.

## Solução

Lockfile regerado com `npm install --package-lock-only`, que restaura as 11 entradas ausentes — todas as variantes de plataforma do `msgpackr-extract` (darwin arm64/x64, linux arm/arm64/x64, win32 x64), mais a cadeia `@emnapi/*` e o `node-gyp-build-optional-packages`.

O lockfile passa a listar **todas** as variantes de plataforma, não só a do host onde foi gerado, então o runner do CI (linux x64, Node 22) resolve sem precisar de rede extra nem de fallback.

Nenhuma dependência direta mudou de versão — o diff toca só `package-lock.json`, em entradas transitivas.

## Screenshots

**Descrição do Screenshot**:
Não se aplica — mudança de tooling/lockfile, sem alteração de UI.

## Outras mudanças

Nenhuma.

## Notas sobre deploy

Assim que este PR entrar na `main`, o workflow `Deploy Vite App to GitHub Pages` volta a rodar até o fim e o site publicado sai do estado congelado. Nenhum passo manual é necessário.

Depois do merge vale conferir se os passos de debug `Show versions` e `Show lockfile info` ainda fazem sentido no workflow — eles foram adicionados para investigar exatamente esta falha e podem ser removidos.

**Validação local executada**:
- `rm -rf node_modules && npm ci` → **falha** no lockfile antigo com o `EUSAGE` acima (reprodução da falha do CI).
- `npm install --package-lock-only` → regenera o lockfile, `166 insertions(+), 38 deletions(-)`.
- `rm -rf node_modules && npm ci` → **passa**, `added 540 packages, and audited 541 packages`, `found 0 vulnerabilities`.
- `npm run build` → **passa**, `✓ built in 460ms`, `precache 61 entries (934.77 KiB)`, gera `dist/sw.js`.
- `npx tsc -b` → limpo.
- `npx eslint .` → limpo.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma — só entradas transitivas opcionais que já eram exigidas pelo `gh-pages`/`msgpackr` e faltavam no lockfile.
