### PR TITLE
fix: impede que um save excluído sobrescreva o save que sobrou

### DIFF
--- a/src/components/Navbar/Config/BattleTab/index.tsx
+++ b/src/components/Navbar/Config/BattleTab/index.tsx
@@ -43,12 +43,14 @@ export function BattleTab({ showComboAction, showHighlight, selectedIndex }: Pro
 
   const isInBattle = player.mode === "battle";
 
-  const playerRank = formatRank(
-    getRank(progress[player.character]?.level ?? 1),
-  );
+  const playerLevel = progress[player.character]?.level ?? 1;
+  const playerRank = formatRank(getRank(playerLevel));
   const playerName = localStorage.getItem("playerName") || "Protagonista";
 
   const battleInfo = battleInfoCtx?.battleInfo;
+  const npcRank = battleInfo
+    ? formatRank(getRank(battleInfo.npcLevel))
+    : playerRank;
 
   const showElementTable = !!battleInfo || isInBattle;
 
@@ -204,7 +206,7 @@ export function BattleTab({ showComboAction, showHighlight, selectedIndex }: Pro
             <BattleCard
               spriteSrc={playerPath(`/${player.character}/default.svg`)}
               name={playerName}
-              level={battleInfo.npcLevel}
+              level={playerLevel}
               rank={playerRank}
               stats={playerSummary}
             />
@@ -221,7 +223,7 @@ export function BattleTab({ showComboAction, showHighlight, selectedIndex }: Pro
                 </span>
               }
               level={battleInfo.npcLevel}
-              rank={playerRank}
+              rank={npcRank}
               stats={[
                 { label: "HP", value: Math.round(battleInfo.npcHp) },
                 { label: "Dano", value: Math.round(battleInfo.npcDamage) },

--- a/src/hooks/menu/useConsumeItem.ts
+++ b/src/hooks/menu/useConsumeItem.ts
@@ -11,6 +11,16 @@ import { sfx } from "@/utils/paths";
 import { activateXpBuff, POTION_CONFIG } from "@/utils/buffs/xpBuff";
 import { FOOD_RESTORE } from "@/gameRules/items/useItem";
 
+/**
+ * Consuming an item from the inventory.
+ *
+ * The returned `consumeItem` reports whether the item was actually used, so
+ * the caller can reject the input instead of destroying an item that does
+ * nothing. An item typed `food` or `consumable` with no `FOOD_RESTORE` amount
+ * and no `POTION_CONFIG` entry — `goat_meat` is one, and it is a unique
+ * flag-gated pickup — used to be removed from the inventory with no effect at
+ * all, which lost it permanently.
+ */
 export function useConsumeItem() {
   const { removeItem } = useInventory();
   const { player } = usePlayer();
@@ -19,23 +29,29 @@ export function useConsumeItem() {
 
   const sfxVolumeRef = useLatestRef(sfxVolume);
 
-  const consumeItemRef = useRef<(id: string) => void>(() => {});
+  const consumeItemRef = useRef<(id: string) => boolean>(() => false);
   consumeItemRef.current = function consumeItem(id: string) {
     const foodAmount = FOOD_RESTORE[id];
+    const potion = POTION_CONFIG[id];
+    if (!foodAmount && !potion) return false;
+
     if (foodAmount) {
       const currentHunger = progress[player.character]?.hunger ?? 0;
-      if (currentHunger >= MAX_HUNGER) return;
+      if (currentHunger >= MAX_HUNGER) return false;
       restoreHunger(player.character, foodAmount);
     }
 
-    const audio = sfx("/player/drinkingPotion.mp3");
+    const audio = sfx(
+      foodAmount ? "/player/eating.mp3" : "/player/drinkingPotion.mp3",
+    );
     audio.volume = 0.6 * (sfxVolumeRef.current / 100);
     audio.play().catch(() => {});
-    const cfg = POTION_CONFIG[id];
-    if (cfg) {
-      activateXpBuff(cfg.durationMs, cfg.multiplier, id);
+
+    if (potion) {
+      activateXpBuff(potion.durationMs, potion.multiplier, id);
     }
     removeItem(id as ItemId);
+    return true;
   };
 
   return { consumeItemRef };

--- a/src/hooks/menu/useItemControls.ts
+++ b/src/hooks/menu/useItemControls.ts
@@ -14,7 +14,7 @@ type Params = {
   items: { id: string }[];
   openPlayerChest: (id: ItemId) => void;
   getEffect: (id: string) => (() => void) | null;
-  consumeItem: (id: string) => void;
+  consumeItem: (id: string) => boolean;
   onReject: (index: number) => void;
   onNoKey: () => void;
 };
@@ -72,7 +72,9 @@ export function useItemControls({
         if (!selectedItem) return false;
 
         if (isConsumableSelected) {
-          consumeItemRef.current(selectedItem.id);
+          if (!consumeItemRef.current(selectedItem.id)) {
+            onRejectRef.current(-1);
+          }
           return true;
         }
 

--- a/src/hooks/menu/useSave.ts
+++ b/src/hooks/menu/useSave.ts
@@ -19,6 +19,17 @@ import { getSceneLabel } from "@/utils/sceneImages";
 import type { SaveTab } from "@/data/saves/tabs";
 import { SAVE_TABS, SAVE_TAB_COUNT } from "@/data/saves/tabs";
 
+/**
+ * Controls for the save menu: slot list, slot switching, deletion and replays.
+ *
+ * Every action that changes the active slot must be followed by a full page
+ * load. The game state lives in React contexts backed by `useCompressedStorage`,
+ * which resolves `slotKey()` at write time — so a running app whose active slot
+ * changed underneath it keeps the previous slot's data in memory and writes it
+ * into the new slot on the next state change, silently overwriting the save the
+ * player just switched to. Deleting the active slot has the same failure mode,
+ * which is why it reloads instead of only refreshing the list.
+ */
 export function useSaveMenu(listRef?: React.RefObject<HTMLDivElement | null>) {
   const { pushControls } = useGameControls();
   const { closeNavbar } = useNavbar();
@@ -153,19 +164,29 @@ export function useSaveMenu(listRef?: React.RefObject<HTMLDivElement | null>) {
         if (confirmDeleteRef.current !== "none") {
           if (idx === 0) {
             playSelectRef.current();
-            clearSlot(confirmDeleteRef.current.slot);
-            if (confirmDeleteRef.current.slot === getActiveSlot()) {
-              const remaining = getUsedSlots();
-              if (remaining.length > 0) setActiveSlot(remaining[0]);
-            }
-            setConfirmDelete("none");
-            refreshRef.current();
-            if (!getUsedSlots().length) {
+            const deletedSlot = confirmDeleteRef.current.slot;
+            const deletedWasActive = deletedSlot === getActiveSlot();
+            clearSlot(deletedSlot);
+            const remaining = getUsedSlots();
+
+            if (remaining.length === 0) {
               closeNavbarRef.current();
               setModeRef.current("explore");
               sessionStorage.setItem("saveSwitchTarget", "/tutorial");
               window.location.replace(import.meta.env.BASE_URL);
+              return;
             }
+
+            if (deletedWasActive) {
+              setActiveSlot(remaining[0]);
+              closeNavbarRef.current();
+              setModeRef.current("explore");
+              window.location.reload();
+              return;
+            }
+
+            setConfirmDelete("none");
+            refreshRef.current();
           } else {
             playMoveRef.current();
             setConfirmDelete("none");

--- a/src/utils/save/slotManager.ts
+++ b/src/utils/save/slotManager.ts
@@ -50,6 +50,15 @@ export function hasAnySave(): boolean {
   return isSlotUsed(0) || isSlotUsed(1);
 }
 
+/**
+ * Every slot-scoped storage key, i.e. every key ever passed through
+ * `slotKey()`. `clearSlot` erases exactly this list, so a key that is written
+ * per slot but missing here survives a deletion and leaks into the next save
+ * started on that slot. Container keys are not listed: they share the
+ * `container_` prefix and are swept separately.
+ *
+ * When you add a `slotKey(...)` call site, add its key here too.
+ */
 const GAME_STATE_KEYS = [
   "game_save",
   "jomasio_inventory",
@@ -83,6 +92,7 @@ const GAME_STATE_KEYS = [
   "char_unlock_dates",
   "difficulty",
   "replays",
+  "visitedLocations",
 ];
 
 export function clearSlot(slot: SlotIndex) {


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Corrige uma **perda de save**: excluir o save ativo tendo dois saves fazia o save excluído sobrescrever o que sobrou.
> - Empilhado sobre #3 (lockfile/deploy). Revise/mescle o #3 antes.
> - Sem migração: saves existentes continuam válidos. O que muda é o comportamento na hora de excluir/trocar de slot.

## Problema

### 1. Excluir o save ativo sobrescreve o save que sobrou

O estado do jogo vive em contexts React apoiados em `useCompressedStorage`, que resolve a chave assim:

```ts
useEffect(() => {
  saveCompressed(slotKey(key), data);
}, [data, key]);
```

`slotKey()` lê `getActiveSlot()` **no momento da escrita**. Ou seja: o slot de destino é decidido a cada gravação, mas `data` continua sendo o que já estava na memória.

O fluxo de exclusão em `useSave.ts` fazia:

```ts
clearSlot(confirmDeleteRef.current.slot);
if (confirmDeleteRef.current.slot === getActiveSlot()) {
  const remaining = getUsedSlots();
  if (remaining.length > 0) setActiveSlot(remaining[0]);   // troca o slot ativo…
}
setConfirmDelete("none");
refreshRef.current();                                       // …e só atualiza a lista
if (!getUsedSlots().length) {
  // recarrega só quando NÃO sobrou nenhum save
  window.location.replace(import.meta.env.BASE_URL);
}
```

Com **dois saves**, excluindo o ativo: o slot ativo passa a apontar para o sobrevivente, mas a página **não recarrega**. O app segue rodando com o save excluído inteiro na memória — progresso, inventário, quests, equipamentos, flags. A partir daí, a primeira mudança de estado qualquer (dar um passo, ganhar XP, pegar um item, abrir um baú) dispara os effects do `useCompressedStorage`, que gravam esses dados **no slot do save sobrevivente**.

Resultado: o jogador exclui o save 1 e o save 2 vira uma cópia do save 1 que ele acabou de apagar.

O caminho de **troca** de slot já tratava isso corretamente:

```ts
setActiveSlot(slot);
closeNavbarRef.current();
setModeRef.current("explore");
window.location.reload();
```

O caminho de exclusão simplesmente não tinha o `reload`.

### 2. `visitedLocations` sobrevive à exclusão do save

`clearSlot` apaga exatamente as chaves da lista `GAME_STATE_KEYS`. `VISITED_LOCATIONS_KEY` (`"visitedLocations"`) é gravada por slot em `useExploreLocation.ts`:

```ts
const storageKey = slotKey(VISITED_LOCATIONS_KEY);
```

…mas nunca foi adicionada à lista. Então ela sobrevive ao `clearSlot` e um jogo novo iniciado naquele slot herda os locais visitados do save anterior — com a missão diária `explore_location` já contabilizada para as salas visitadas naquele dia.

## Solução

### `src/hooks/menu/useSave.ts`

O bloco de confirmação de exclusão foi reescrito com os três desfechos explícitos, em vez de dois `if`s independentes sobre estado já mutado:

```ts
const deletedSlot = confirmDeleteRef.current.slot;
const deletedWasActive = deletedSlot === getActiveSlot();
clearSlot(deletedSlot);
const remaining = getUsedSlots();

if (remaining.length === 0) {
  // nenhum save sobrou → vai para o tutorial
  ...
  window.location.replace(import.meta.env.BASE_URL);
  return;
}

if (deletedWasActive) {
  // sobrou save e o excluído era o ativo → recarrega, igual à troca de slot
  setActiveSlot(remaining[0]);
  closeNavbarRef.current();
  setModeRef.current("explore");
  window.location.reload();
  return;
}

// excluído era o inativo → nada em memória aponta para ele, só atualiza a lista
setConfirmDelete("none");
refreshRef.current();
```

`deletedWasActive` é capturado **antes** do `clearSlot`, porque a comparação original lia `getActiveSlot()` depois de já ter potencialmente mexido no slot ativo.

Excluir o slot **inativo** continua sem recarregar — é correto, nada em memória aponta para ele.

O porquê do reload foi documentado no docstring de `useSaveMenu`, para que a próxima pessoa que mexer no fluxo não o remova como "otimização".

### `src/utils/save/slotManager.ts`

`"visitedLocations"` adicionada a `GAME_STATE_KEYS`, e a lista ganhou um docstring dizendo o que ela é e que precisa acompanhar novos call sites de `slotKey()`.

Auditei **todas** as chamadas de `slotKey(...)` do projeto contra a lista, resolvendo cada constante para o seu literal. Só `visitedLocations` estava faltando:

| Chave | Literal | Na lista |
| --- | --- | --- |
| `"game_save"`, `"play_time"`, `"scene_return_positions"` | idem | ✅ |
| `BATTLE_STATS_KEY` … `WEEKLY_QUEST_DATE_KEY` (22 constantes) | — | ✅ |
| **`VISITED_LOCATIONS_KEY`** | **`visitedLocations`** | ❌ → corrigido |
| `cfg.storageKey`, `storageKey`, `key` (dinâmicas) | `container_*`, `library_return_position`, `cafeteria_return_position`, e as chaves de `useCompressedStorage` | ✅ (prefixo `container_` é varrido à parte) |

## Screenshots

**Descrição do Screenshot**:
Não se aplica — a mudança é de fluxo de estado/armazenamento, sem alteração visual. O menu de saves renderiza igual; o que muda é que excluir o save ativo passa a recarregar a página.

## Outras mudanças

Nenhuma.

## Notas sobre deploy

Sem migração e sem passo manual. Saves já existentes seguem válidos.

Uma `visitedLocations` órfã que já esteja no `localStorage` de um jogador (resíduo de um save excluído antes desta correção) continua lá até a próxima exclusão daquele slot — o efeito é no máximo uma missão diária de exploração já marcada, que se resolve sozinha na virada do dia.

**Validação local executada**:
- `npx tsc -b` → limpo.
- `npx eslint .` → limpo.
- Auditoria de `slotKey(...)` × `GAME_STATE_KEYS` resolvida por script, tabela acima.
- Não exercitei o fluxo de exclusão no browser: reproduzir exige dois saves reais e o efeito só aparece em gravações posteriores. A correção está justificada pela leitura do fluxo e espelha o caminho de troca de slot, que já existia e já recarregava.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
