### PR TITLE
fix: não destruir item consumível sem efeito + som certo ao comer

### DIFF
--- a/src/hooks/menu/useConsumeItem.ts
+++ b/src/hooks/menu/useConsumeItem.ts
@@ -11,6 +11,16 @@ import { sfx } from "@/utils/paths";
 import { activateXpBuff, POTION_CONFIG } from "@/utils/buffs/xpBuff";
 import { FOOD_RESTORE } from "@/gameRules/items/useItem";
 
+/**
+ * Consuming an item from the inventory.
+ *
+ * The returned `consumeItem` reports whether the item was actually used, so
+ * the caller can reject the input instead of destroying an item that does
+ * nothing. An item typed `food` or `consumable` with no `FOOD_RESTORE` amount
+ * and no `POTION_CONFIG` entry — `goat_meat` is one, and it is a unique
+ * flag-gated pickup — used to be removed from the inventory with no effect at
+ * all, which lost it permanently.
+ */
 export function useConsumeItem() {
   const { removeItem } = useInventory();
   const { player } = usePlayer();
@@ -19,23 +29,29 @@ export function useConsumeItem() {
 
   const sfxVolumeRef = useLatestRef(sfxVolume);
 
-  const consumeItemRef = useRef<(id: string) => void>(() => {});
+  const consumeItemRef = useRef<(id: string) => boolean>(() => false);
   consumeItemRef.current = function consumeItem(id: string) {
     const foodAmount = FOOD_RESTORE[id];
+    const potion = POTION_CONFIG[id];
+    if (!foodAmount && !potion) return false;
+
     if (foodAmount) {
       const currentHunger = progress[player.character]?.hunger ?? 0;
-      if (currentHunger >= MAX_HUNGER) return;
+      if (currentHunger >= MAX_HUNGER) return false;
       restoreHunger(player.character, foodAmount);
     }
 
-    const audio = sfx("/player/drinkingPotion.mp3");
+    const audio = sfx(
+      foodAmount ? "/player/eating.mp3" : "/player/drinkingPotion.mp3",
+    );
     audio.volume = 0.6 * (sfxVolumeRef.current / 100);
     audio.play().catch(() => {});
-    const cfg = POTION_CONFIG[id];
-    if (cfg) {
-      activateXpBuff(cfg.durationMs, cfg.multiplier, id);
+
+    if (potion) {
+      activateXpBuff(potion.durationMs, potion.multiplier, id);
     }
     removeItem(id as ItemId);
+    return true;
   };
 
   return { consumeItemRef };

--- a/src/hooks/menu/useItemControls.ts
+++ b/src/hooks/menu/useItemControls.ts
@@ -14,7 +14,7 @@ type Params = {
   items: { id: string }[];
   openPlayerChest: (id: ItemId) => void;
   getEffect: (id: string) => (() => void) | null;
-  consumeItem: (id: string) => void;
+  consumeItem: (id: string) => boolean;
   onReject: (index: number) => void;
   onNoKey: () => void;
 };
@@ -72,7 +72,9 @@ export function useItemControls({
         if (!selectedItem) return false;
 
         if (isConsumableSelected) {
-          consumeItemRef.current(selectedItem.id);
+          if (!consumeItemRef.current(selectedItem.id)) {
+            onRejectRef.current(-1);
+          }
           return true;
         }
 


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Corrige a **destruição permanente** da Carne de bode (`goat_meat`): item único, obtido uma só vez, que ao ser usado sumia sem efeito nenhum.
> - **Decisão sua:** `goat_meat` não tem valor em `FOOD_RESTORE`. Este PR só impede que ele seja destruído — dar um valor de fome a ele é balanceamento e ficou de fora de propósito. Se quiser, digo qual valor e abro um PR em cima.
> - Topo da pilha: #5 → #4 → #3. Revise na ordem.

## Problema

### 1. Item consumível sem efeito era destruído mesmo assim

`consumeItem` é o caminho que o inventário usa para **todo** item tipado `consumable` ou `food` — `useItemControls` checa `isConsumableSelected` antes de consultar `getEffect`, então é sempre ele que roda:

```ts
if (isConsumableSelected) {
  consumeItemRef.current(selectedItem.id);
  return true;
}
```

Mas `consumeItem` só conhece dois efeitos: um valor em `FOOD_RESTORE` e uma entrada em `POTION_CONFIG`. Um item que não casa com nenhum dos dois caía direto no fim da função:

```ts
const foodAmount = FOOD_RESTORE[id];
if (foodAmount) { ... }              // não entra

const audio = sfx("/player/drinkingPotion.mp3");
audio.play().catch(() => {});
const cfg = POTION_CONFIG[id];
if (cfg) { ... }                     // não entra

removeItem(id as ItemId);            // ← mas isto sempre roda
```

`goat_meat` é exatamente esse caso. Ele é `type: "food"` em `src/data/items/food.ts`, não tem entrada em `FOOD_RESTORE` (que só cobre `queijo_cabra`, `porcao_arroz` e `ovo_piupiu`), e é um pickup único na BrodiClass protegido pela flag `picked_goat_meat`:

```ts
// src/interactions/brodiClass.ts
item: { id: "goat_meat" },
flagId: "picked_goat_meat",
```

```tsx
// src/features/brodiClass/index.tsx
const gotGoatMeat = hasFlag("picked_goat_meat");
{ x: 10, y: 8, visible: !gotGoatMeat, image: "/assets/items/goat_meat.svg" },
```

Ou seja: uma vez pego, o sprite some do mapa e a flag impede outro pickup. Usar o item o apagava do inventário, não fazia nada, e ele **não podia mais ser obtido**.

Nota lateral: a guarda de fome cheia (`if (currentHunger >= MAX_HUNGER) return;`) também só existia dentro do `if (foodAmount)`, então nem essa proteção alcançava um item sem valor de restauração.

### 2. Comer tocava o som de beber poção

`consumeItem` tocava `drinkingPotion.mp3` incondicionalmente, para comida e para poção. O `eating.mp3` existe (`public/assets/songs/soundEffects/player/eating.mp3`) e é usado no `getEffect` de `useItem.ts`:

```ts
const restoreAmount = FOOD_RESTORE[itemId];
if (restoreAmount) {
  return () => {
    if (progress[player.character].hunger >= MAX_HUNGER) return;
    playSFX?.("/assets/songs/soundEffects/player/eating.mp3", 0.8);
    ...
```

Só que esse ramo de `getEffect` é **inalcançável pelo inventário** — `isConsumableSelected` vence antes. O som errado é o que o jogador de fato ouve.

## Solução

### `src/hooks/menu/useConsumeItem.ts`

`consumeItem` passa a retornar `boolean` — se o item foi usado ou não — e sai **antes** de encostar no inventário quando não há efeito a aplicar:

```ts
const consumeItemRef = useRef<(id: string) => boolean>(() => false);
consumeItemRef.current = function consumeItem(id: string) {
  const foodAmount = FOOD_RESTORE[id];
  const potion = POTION_CONFIG[id];
  if (!foodAmount && !potion) return false;

  if (foodAmount) {
    const currentHunger = progress[player.character]?.hunger ?? 0;
    if (currentHunger >= MAX_HUNGER) return false;
    restoreHunger(player.character, foodAmount);
  }

  const audio = sfx(
    foodAmount ? "/player/eating.mp3" : "/player/drinkingPotion.mp3",
  );
  audio.volume = 0.6 * (sfxVolumeRef.current / 100);
  audio.play().catch(() => {});

  if (potion) {
    activateXpBuff(potion.durationMs, potion.multiplier, id);
  }
  removeItem(id as ItemId);
  return true;
};
```

Três mudanças de comportamento, todas conservadoras:

1. **Sem efeito → nada acontece.** O item permanece no inventário.
2. **Som escolhido pelo efeito aplicado.** Comida toca `eating.mp3`, poção toca `drinkingPotion.mp3`.
3. **Fome cheia devolve `false`** em vez de `undefined`, para o chamador poder dar retorno visual.

`POTION_CONFIG[id]` passou a ser lido uma vez no topo, em `potion`, já que agora é consultado duas vezes.

### `src/hooks/menu/useItemControls.ts`

O tipo do parâmetro acompanhou (`consumeItem: (id: string) => boolean`) e o `false` é roteado para o `onReject` que já existia:

```ts
if (isConsumableSelected) {
  if (!consumeItemRef.current(selectedItem.id)) {
    onRejectRef.current(-1);
  }
  return true;
}
```

`onReject` é o mesmo callback que o inventário já usa para item inutilizável — ele dispara a animação de rejeição em `Inventory/index.tsx`. Então o jogador vê o mesmo retorno de sempre, em vez de perder o item em silêncio.

### Fora de escopo, mas registrando

Os ramos de comida e poção dentro de `getEffect` (`src/gameRules/items/useItem.ts`) são código morto para o caminho do inventário — foi a divergência entre eles e o `consumeItem` que produziu o som errado. Não removi porque `useItem.ts` foi mexido recentemente e a limpeza merece um PR próprio, mas vale unificar.

## Screenshots

**Descrição do Screenshot**:
Não se aplica — a mudança é de comportamento (o que acontece ao confirmar um item), não de layout. A animação de rejeição já existia e é reaproveitada sem alteração visual.

## Outras mudanças

Nenhuma.

## Notas sobre deploy

Sem migração, sem env var, sem passo manual.

Jogadores que já usaram a Carne de bode antes desta correção **não a recuperam** — a flag `picked_goat_meat` continua marcada e o item já saiu do inventário. Se quiser desfazer isso para quem foi afetado, é um script à parte, não coberto aqui.

**Validação local executada**:
- `npx tsc -b` → limpo. O `boolean` no retorno de `consumeItem` propaga pelos tipos de `useItemControls` sem erro.
- `npx eslint .` → limpo.
- Não exercitei o caso no browser: reproduzir exige um save com progresso até a BrodiClass e com a Carne de bode no inventário. Injetar o item direto no `localStorage` não sobreviveu ao boot (o contexto de inventário reescreve o slot na montagem), então a verificação aqui é por leitura do fluxo e pelos tipos, não visual.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
