### PR TITLE
fix: consumir tombstones no useSceneLayers e destravar o build

### DIFF
--- a/src/components/Game/Scenes/Explore/index.tsx
+++ b/src/components/Game/Scenes/Explore/index.tsx
@@ -227,10 +227,11 @@ export function ExploreScene({
     navigateWithFade,
   });
 
-  const { tombstones, fadingIds, collectAt } = useSceneTombstones({
-    locationId: tombstoneLocationId,
-    onMessage: setPopup,
-  });
+  const { tombstones, collectableTombstones, fadingIds, collectAt } =
+    useSceneTombstones({
+      locationId: tombstoneLocationId,
+      onMessage: setPopup,
+    });
 
   useSceneNavigation({
     player,
@@ -319,7 +320,7 @@ export function ExploreScene({
     interactionKeys,
     interactionLabels,
     tileDialogues,
-    tombstones,
+    tombstones: collectableTombstones,
   });
 
   const { TILE_SIZE, cameraX, cameraY, PLAYER_SIZE, MAP_COLS, MAP_ROWS } =

--- a/src/hooks/scene/useSceneLayers.ts
+++ b/src/hooks/scene/useSceneLayers.ts
@@ -28,6 +28,16 @@ type Params = {
   tombstones?: { x: number; y: number }[];
 };
 
+/**
+ * Deriva o tile em frente ao jogador e o hint de interação daquele tile.
+ *
+ * A ordem dos testes espelha a cadeia de `onInteract` do ExploreScene
+ * (npc → tileDialogue → lápide → placa): hint e ação precisam concordar,
+ * senão o jogador lê um rótulo e recebe outra interação.
+ *
+ * `tombstones` deve conter só as lápides coletáveis — as que estão em
+ * fade-out ainda bloqueiam o tile, mas não aceitam mais interação.
+ */
 export function useSceneLayers({
   player,
   map,
@@ -69,10 +79,13 @@ export function useSceneLayers({
     );
     if (pickup) return "[L] Pegar";
 
+    if (tileDialogues?.[`${x},${y}`]) return "[L] Interagir";
+
+    const tombstone = tombstones?.find((t) => t.x === x && t.y === y);
+    if (tombstone) return "[L] Recolher";
+
     const plate = plates.find((p) => p.gridX === x && p.gridY === y);
     if (plate) return "[L] Interagir";
-
-    if (tileDialogues?.[`${x},${y}`]) return "[L] Interagir";
 
     return null;
   }, [
@@ -85,6 +98,7 @@ export function useSceneLayers({
     interactionKeys,
     interactionLabels,
     tileDialogues,
+    tombstones,
   ]);
 
   return { frontTile, interactionHint };

--- a/src/hooks/tombstone/useSceneTombstones.ts
+++ b/src/hooks/tombstone/useSceneTombstones.ts
@@ -107,6 +107,7 @@ export function useSceneTombstones({ locationId, onMessage }: Params) {
 
   return {
     tombstones: [...active, ...fading],
+    collectableTombstones: active,
     fadingIds: fading.map((t) => t.id),
     collectAt,
   };


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Este PR desbloqueia o build: na `main`, `npm run build` falha em `tsc -b`.
> - A feature de lápide continua **não conectada** ao jogo (ver "Outras mudanças"). O hint só aparece quando ela for ligada.

## Problema

`useSceneLayers` recebia `tombstones` no destructuring e nunca lia o valor. Dois efeitos:

1. **Build quebrado.** `tsc -b` falha com `TS6133: 'tombstones' is declared but its value is never read` (`src/hooks/scene/useSceneLayers.ts:42`), e o ESLint acusa o mesmo com `@typescript-eslint/no-unused-vars`. `npm run build` roda `tsc -b` antes do Vite, então nada compila.
2. **Sem hint de interação.** O tile ocupado por uma lápide caía no `return null` do `interactionHint`, mesmo com a cadeia de `onInteract` do `ExploreScene` já chamando `collectAt(front.x, front.y)`. O jogador ficava de frente para a lápide sem nenhum rótulo dizendo que dá para interagir.

Havia ainda uma divergência de ordem pré-existente: o hint testava `tileDialogues` **depois** de `plates`, enquanto o `onInteract` testa `tileDialogue` **antes** de `plate`. Inserir a lápide no meio dessa cadeia exigia alinhar as duas ordens, senão o rótulo lido e a ação executada poderiam discordar.

## Solução

### `hooks/scene/useSceneLayers.ts`

- `tombstones` passa a ser consultado e emite `"[L] Recolher"`.
- O teste de `tileDialogues` subiu para antes da lápide, deixando a ordem do hint igual à do `onInteract`: npc → tileDialogue → lápide → placa.
- `tombstones` entrou nas deps do `useMemo`.
- Docstring registrando o contrato de ordem e o fato de que a lista deve conter só lápides coletáveis.

### `hooks/tombstone/useSceneTombstones.ts`

- Novo retorno `collectableTombstones` (só as ativas). O retorno `tombstones` existente continua com `[...active, ...fading]`, porque render e colisão precisam das duas.

### `components/Game/Scenes/Explore/index.tsx`

- Passa `collectableTombstones` para o `useSceneLayers`. Lápide em fade-out continua bloqueando o tile, mas não oferece mais o rótulo — antes ela ofereceria um `"[L] Recolher"` que o `collectAt` recusaria.

## Screenshots

**Descrição do Screenshot**: Validado no browser com Playwright MCP em `/hall/one`, com uma lápide semeada em `localStorage` no tile em frente ao spawn. Confirmado: o sprite `assets/npcs/tombstone/front.svg` renderiza, o rótulo `[L] Recolher` aparece abaixo dele, e acionar `L` dispara a coleta ("Você recolheu os restos de Slimita: Alma de Chefão x1."), remove a lápide do save e não gera nenhum erro de console. O wiring temporário usado no teste foi revertido e não faz parte do diff.

## Outras mudanças

- Nenhuma.

**Fora de escopo, mas registrado para não passar por esquecimento:** a feature de lápide ainda não está ligada ponta a ponta na `main`. Nenhuma cena passa `tombstoneLocationId`, e `prepareTombstoneSpawn` / `spawnVictoryTombstone` do `TombstoneContext` não têm nenhum call site. Ou seja, hoje nenhuma lápide chega a nascer. Este PR conserta o hint e o build; ligar o spawn na vitória e definir o `tombstoneLocationId` de cada cena é trabalho de feature, não de correção.

## Notas sobre deploy

Nenhum passo especial. Sem migration, sem rebuild extra além do normal.

**Validação local executada**:
- `npx tsc -b --force` → sem erros (na `main` falhava com TS6133).
- `npx eslint src/hooks/scene/useSceneLayers.ts src/hooks/tombstone/useSceneTombstones.ts src/components/Game/Scenes/Explore/index.tsx` → limpo.
- Playwright MCP em `http://localhost:5173/react-jomasio-adventures/#/hall/one` → hint renderizado, interação executada, `browser_console_messages` sem erros.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
