### PR TITLE
fix: manter os timers de fome e sono vivos entre renders do provider

### DIFF
--- a/src/hooks/hunger/useHungerTimer.ts
+++ b/src/hooks/hunger/useHungerTimer.ts
@@ -1,15 +1,26 @@
 import { useEffect, useRef } from "react";
 import { usePlayer } from "@/contexts/PlayerContext";
 import { useCharacterProgress } from "@/contexts/CharacterProgressContext";
+import { useLatestRef } from "@/hooks/useLatestRef";
 import {
   DIFFICULTY_HUNGER_RATE,
   HUNGER_INTERVAL_MS,
   HUNGER_TICK_MS,
 } from "@/data/player/hunger";
 
+/**
+ * Drena a fome do personagem ativo enquanto o jogo está aberto.
+ *
+ * `reduceHunger` entra por ref e fica fora das dependências do effect.
+ * O CharacterProgressProvider recria seus métodos a cada render, então
+ * tê-los nas deps reiniciava o intervalo e zerava `accumulatedRef` antes
+ * de qualquer tick de 30s completar. Com o regen de HP gravando
+ * progresso a cada segundo, a fome simplesmente nunca caía.
+ */
 export function useHungerTimer() {
   const { difficulty, player } = usePlayer();
   const { reduceHunger } = useCharacterProgress();
+  const reduceHungerRef = useLatestRef(reduceHunger);
   const accumulatedRef = useRef(0);
 
   useEffect(() => {
@@ -20,7 +31,7 @@ export function useHungerTimer() {
       accumulatedRef.current += HUNGER_TICK_MS;
       const slots = Math.floor(accumulatedRef.current / HUNGER_INTERVAL_MS);
       if (slots > 0) {
-        reduceHunger(player.character, Math.abs(rate) * slots);
+        reduceHungerRef.current(player.character, Math.abs(rate) * slots);
         accumulatedRef.current -= slots * HUNGER_INTERVAL_MS;
       }
     }, HUNGER_TICK_MS);
@@ -29,5 +40,5 @@ export function useHungerTimer() {
       clearInterval(interval);
       accumulatedRef.current = 0;
     };
-  }, [difficulty, player.character, reduceHunger]);
+  }, [difficulty, player.character, reduceHungerRef]);
 }

--- a/src/hooks/sleep/useSleepTimer.ts
+++ b/src/hooks/sleep/useSleepTimer.ts
@@ -1,15 +1,26 @@
 import { useEffect, useRef } from "react";
 import { usePlayer } from "@/contexts/PlayerContext";
 import { useCharacterProgress } from "@/contexts/CharacterProgressContext";
+import { useLatestRef } from "@/hooks/useLatestRef";
 import {
   DIFFICULTY_SLEEP_RATE,
   SLEEP_INTERVAL_MS,
   SLEEP_TICK_MS,
 } from "@/data/player/sleep";
 
+/**
+ * Drena o sono do personagem ativo enquanto o jogo está aberto.
+ *
+ * `reduceSleep` entra por ref e fica fora das dependências do effect.
+ * O CharacterProgressProvider recria seus métodos a cada render, então
+ * tê-los nas deps reiniciava o intervalo e zerava `accumulatedRef` antes
+ * de qualquer tick de 30s completar. Com o regen de HP gravando
+ * progresso a cada segundo, o sono simplesmente nunca caía.
+ */
 export function useSleepTimer() {
   const { difficulty, player } = usePlayer();
   const { reduceSleep } = useCharacterProgress();
+  const reduceSleepRef = useLatestRef(reduceSleep);
   const accumulatedRef = useRef(0);
 
   useEffect(() => {
@@ -20,7 +31,7 @@ export function useSleepTimer() {
       accumulatedRef.current += SLEEP_TICK_MS;
       const slots = Math.floor(accumulatedRef.current / SLEEP_INTERVAL_MS);
       if (slots > 0) {
-        reduceSleep(player.character, Math.abs(rate) * slots);
+        reduceSleepRef.current(player.character, Math.abs(rate) * slots);
         accumulatedRef.current -= slots * SLEEP_INTERVAL_MS;
       }
     }, SLEEP_TICK_MS);
@@ -29,5 +40,5 @@ export function useSleepTimer() {
       clearInterval(interval);
       accumulatedRef.current = 0;
     };
-  }, [difficulty, player.character, reduceSleep]);
+  }, [difficulty, player.character, reduceSleepRef]);
 }


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Mudança de gameplay: fome e sono voltam a cair de verdade. Saves em andamento vão começar a drenar os dois recursos que hoje ficam parados.
> - A causa-raiz (todo context passa `value={{...}}` inline, sem `useMemo`) **não** é resolvida aqui — só o sintoma nestes dois timers. O saneamento geral dos contexts vai no PR dos itens de severidade baixa.

## Problema

`useHungerTimer` e `useSleepTimer` listavam `reduceHunger` / `reduceSleep` nas dependências do `useEffect`:

```ts
}, [difficulty, player.character, reduceHunger]);
```

O `CharacterProgressProvider` declara esses métodos como funções comuns e entrega tudo num objeto inline (`value={{...}}`, `CharacterProgressContext.tsx:313`). Ou seja: **identidade nova a cada render do provider**. Cada render derrubava o `setInterval` e, no cleanup, zerava o `accumulatedRef`.

Com `HUNGER_TICK_MS = 30s` e `HUNGER_INTERVAL_MS = 60s`, perder 1 ponto de fome exige 60 segundos ininterruptos de acumulação. E `useRegenTimer` grava `battleHP` **uma vez por segundo** enquanto o HP está abaixo do máximo. Resultado prático: depois de qualquer dano, o acumulador nunca sobrevivia, e fome e sono simplesmente paravam. O mesmo vale para qualquer outra escrita em `progress` — XP, moeda, kill.

## Solução

Ler os dois callbacks por `useLatestRef` e tirá-los das dependências. O intervalo passa a reiniciar só quando o personagem ou a dificuldade muda, que é a semântica pretendida.

O ref é a saída certa aqui e não um curativo: mesmo com os contexts memoizados no futuro, um timer de mundo não deve ter sua cadência amarrada à cadência de render de um provider. A docstring de cada hook registra esse motivo.

## Screenshots

**Descrição do Screenshot**: Não se aplica — sem mudança visual. A validação foi comportamental, medindo o estado persistido no browser (ver "Notas sobre deploy").

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Nenhum passo especial. Sem migration, sem env var.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado); os dois arquivos deste PR passam limpos.
- `npx eslint src/hooks/hunger/useHungerTimer.ts src/hooks/sleep/useSleepTimer.ts` → limpo.
- **A/B no browser com Playwright MCP**, em `/hall/one`, dificuldade `medium`, `battleHP` semeado baixo para manter o regen escrevendo em `progress` a cada segundo, e `HUNGER_TICK_MS`/`HUNGER_INTERVAL_MS` reduzidos temporariamente para `1s`/`2s` só durante a medição:

  | | fome antes | fome depois | janela | regen no período |
  | --- | --- | --- | --- | --- |
  | Código da `main` | 100 | **100** | 15s | `battleHP` 22 → 52 |
  | Com o fix | 74 | **69** | 10s | `battleHP` 48 → 53 |

  Sem o fix a fome não se move nem um ponto. Com o fix cai na taxa exata esperada (5 pontos em 10s a 1 ponto por 2s). Os valores temporários de tick foram revertidos e não fazem parte do diff.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
