### PR TITLE
fix: dar taxa de fome e sono para a dificuldade insano

### DIFF
--- a/src/components/Game/Navbar/ExploreNavbar/Config/Difficulty/index.tsx
+++ b/src/components/Game/Navbar/ExploreNavbar/Config/Difficulty/index.tsx
@@ -3,7 +3,7 @@ import styles from "../styles.module.css";
 import { DIFFICULTY_LABEL } from "@/data/npc/difficultyLabels";
 
 type Props = {
-  difficultyList: string[];
+  difficultyList: NpcDifficulty[];
   selectedIndex: number;
   selectedColumn: number;
   activeDifficulty: NpcDifficulty;

--- a/src/data/npc/difficultyLabels.ts
+++ b/src/data/npc/difficultyLabels.ts
@@ -1,4 +1,4 @@
-export const DIFFICULTY_LABEL: Record<string, string> = {
+export const DIFFICULTY_LABEL: Record<NpcDifficulty, string> = {
   easy: "Fácil",
   medium: "Médio",
   hard: "Difícil",

--- a/src/data/player/hunger.ts
+++ b/src/data/player/hunger.ts
@@ -1,8 +1,9 @@
 export const HUNGER_TICK_MS = 30_000; // check every 30s
 export const HUNGER_INTERVAL_MS = 60_000; // 1 min
 
-export const DIFFICULTY_HUNGER_RATE: Record<string, number> = {
+export const DIFFICULTY_HUNGER_RATE: Record<NpcDifficulty, number> = {
   easy: 0,
   medium: -1,
   hard: -2,
+  insano: -3,
 };

--- a/src/data/player/sleep.ts
+++ b/src/data/player/sleep.ts
@@ -1,8 +1,9 @@
 export const SLEEP_TICK_MS = 30_000; // check every 30s
 export const SLEEP_INTERVAL_MS = 60_000; // 1 min
 
-export const DIFFICULTY_SLEEP_RATE: Record<string, number> = {
+export const DIFFICULTY_SLEEP_RATE: Record<NpcDifficulty, number> = {
   easy: 0,
   medium: -1,
   hard: -2,
+  insano: -3,
 };

--- a/src/data/player/xp.ts
+++ b/src/data/player/xp.ts
@@ -1,4 +1,4 @@
-export const DIFFICULTY_XP_MULTIPLIER: Record<string, number> = {
+export const DIFFICULTY_XP_MULTIPLIER: Record<NpcDifficulty, number> = {
   easy: 0.75,
   medium: 1,
   hard: 1.5,


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Mudança de balanceamento: `insano` passa a drenar fome e sono a `-3` por minuto. Hoje drena `0`.
> - `insano` ainda não é selecionável pelo menu (`DIFFICULTY` em `configConstants.ts` só lista easy/medium/hard, e a UI mostra o item com cadeado). Este PR não desbloqueia nada — só faz a dificuldade se comportar corretamente quando ela for liberada ou quando já estiver gravada no save.

## Problema

`DIFFICULTY_HUNGER_RATE` e `DIFFICULTY_SLEEP_RATE` eram `Record<string, number>` com apenas três chaves:

```ts
export const DIFFICULTY_HUNGER_RATE: Record<string, number> = {
  easy: 0,
  medium: -1,
  hard: -2,
};
```

Mas `NpcDifficulty` é `"easy" | "medium" | "hard" | "insano"`. Em `insano` o lookup devolve `undefined`, o guard `if (!rate || rate === 0) return;` dispara e **nenhum dos dois intervalos chega a ser criado**. Ou seja: a dificuldade mais difícil do jogo não tem fome nem sono — estritamente mais fácil que `hard` nesses dois eixos.

O `Record<string, number>` é o que deixa isso passar: com a chave faltando o TypeScript não reclama, porque qualquer string é índice válido. `SettingsContext.tsx:99` já aceita `"insano"` vindo do storage, e `useScene.ts:549` já ramifica em cima dela, então o valor circula de verdade pelo runtime.

## Solução

### Taxa que faltava

`insano: -3` em `hunger.ts` e `sleep.ts`, continuando a progressão `easy 0 → medium -1 → hard -2`.

### Tipo que deixa o buraco visível

Todos os mapas indexados por dificuldade passam a ser `Record<NpcDifficulty, ...>`:

| Arquivo | Antes | Tinha todas as chaves? |
| --- | --- | --- |
| `data/player/hunger.ts` | `Record<string, number>` | Não — faltava `insano` |
| `data/player/sleep.ts` | `Record<string, number>` | Não — faltava `insano` |
| `data/player/xp.ts` | `Record<string, number>` | Sim, mas com o mesmo tipo frouxo |
| `data/npc/difficultyLabels.ts` | `Record<string, string>` | Sim, mas com o mesmo tipo frouxo |

Com isso, adicionar uma quinta dificuldade no futuro passa a quebrar a compilação nos quatro pontos em vez de degradar em silêncio.

### Efeito colateral do tipo mais estrito

Fechar `DIFFICULTY_LABEL` expôs um `TS7053` em `DifficultySection`, cuja prop `difficultyList` estava tipada como `string[]`. A lista que chega ali já é `NpcDifficulty[]` (`configConstants.ts:3`), então a prop foi corrigida para acompanhar o call site.

## Screenshots

**Descrição do Screenshot**: A mudança na tela de configuração é só de tipagem, sem delta de runtime. Ainda assim, validado no browser com Playwright MCP: o menu de Config abre normalmente e a seção de dificuldade continua listando FÁCIL / MÉDIO / DIFÍCIL mais o item INSANO travado, sem erro de console.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Nenhum passo especial. Sem migration, sem env var. Saves que já tenham `difficulty_<slot>` igual a `insano` passam a drenar fome e sono no próximo carregamento.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint` nos cinco arquivos tocados → limpo.
- Playwright MCP: reload em `/hall/one` sem erro de console, menu de Config aberto e conferido.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
