### PR TITLE
fix: fazer o clearSlot apagar toda chave escopada por slot

### DIFF
--- a/src/data/containers/index.ts
+++ b/src/data/containers/index.ts
@@ -1,8 +1,12 @@
+import {
+  CONTAINER_KEY_PREFIX,
+  type SlotScopedKey,
+} from "@/services/save/slotManager";
 import type { ContainerDef } from "@/utils/types/container";
 
-export const CONTAINER_STORAGE_PREFIX = "container_";
+export const CONTAINER_STORAGE_PREFIX = CONTAINER_KEY_PREFIX;
 
-export function containerStorageKey(id: string) {
+export function containerStorageKey(id: string): SlotScopedKey {
   return `${CONTAINER_STORAGE_PREFIX}${id}`;
 }
 

--- a/src/gameRules/rewards/progress.ts
+++ b/src/gameRules/rewards/progress.ts
@@ -1,5 +1,6 @@
 import { isCharRewardId, type RewardDef } from "@/data/rewards";
 import { REWARDS_KEY } from "@/data/storageKeys";
+import { slotKey } from "@/services/save/slotManager";
 import { getBlockCount } from "@/utils/rewards/blockCounter";
 import {
   getDamageDealtStats,
@@ -12,10 +13,26 @@ import {
 
 export type RewardsProgress = Record<string, number>;
 
+/**
+ * Lê o progresso de recompensas do slot ativo.
+ *
+ * `rewards` sempre constou de `GAME_STATE_KEYS`, mas era gravado sem
+ * `slotKey()` — a chave global sobrevivia ao `clearSlot` e era
+ * compartilhada pelos dois slots. A leitura adota a chave antiga uma
+ * única vez, migrando o progresso para o slot ativo em vez de zerá-lo.
+ */
 export function loadProgress(): RewardsProgress {
   try {
-    const raw = localStorage.getItem(REWARDS_KEY);
-    return raw ? (JSON.parse(raw) as RewardsProgress) : {};
+    const raw = localStorage.getItem(slotKey(REWARDS_KEY));
+    if (raw) return JSON.parse(raw) as RewardsProgress;
+
+    const legacy = localStorage.getItem(REWARDS_KEY);
+    if (!legacy) return {};
+
+    const migrated = JSON.parse(legacy) as RewardsProgress;
+    saveProgress(migrated);
+    localStorage.removeItem(REWARDS_KEY);
+    return migrated;
   } catch {
     return {};
   }
@@ -23,7 +40,7 @@ export function loadProgress(): RewardsProgress {
 
 export function saveProgress(data: RewardsProgress): void {
   try {
-    localStorage.setItem(REWARDS_KEY, JSON.stringify(data));
+    localStorage.setItem(slotKey(REWARDS_KEY), JSON.stringify(data));
   } catch {}
 }
 

--- a/src/hooks/container/useContainer.ts
+++ b/src/hooks/container/useContainer.ts
@@ -6,11 +6,12 @@ import { useLatestRef } from "@/hooks/useLatestRef";
 import { useMenuSFX } from "@/hooks/menu/useMenuSFX";
 import { useCompressedStorage } from "@/hooks/useCompressedStorage";
 
+import type { SlotScopedKey } from "@/services/save/slotManager";
 import type { ContainerSlots } from "@/utils/types/container";
 import type { InventoryItem } from "@/utils/types/player/inventory";
 
 type Params = {
-  storageKey: string;
+  storageKey: SlotScopedKey;
   defaultSlots: ContainerSlots;
   size: number;
   cols?: number;

--- a/src/hooks/useCompressedStorage.ts
+++ b/src/hooks/useCompressedStorage.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
 import { saveCompressed, loadCompressed } from "@/services/save/storageService";
-import { slotKey } from "@/services/save/slotManager";
+import { slotKey, type SlotScopedKey } from "@/services/save/slotManager";
 
 export function useCompressedStorage<T>(
-  key: string,
+  key: SlotScopedKey,
   defaultValue: T,
   normalize?: (data: T) => T,
 ) {

--- a/src/services/save/slotManager.ts
+++ b/src/services/save/slotManager.ts
@@ -2,7 +2,23 @@ import type { StorageLike } from "./storageService";
 
 const ACTIVE_SLOT_KEY = "active_save_slot";
 
+export const CONTAINER_KEY_PREFIX = "container_";
+
 export type SlotIndex = 0 | 1;
+
+/**
+ * Chave que `slotKey()` aceita.
+ *
+ * Fechar o tipo em `GAME_STATE_KEYS` é o que mantém o invariante do
+ * `clearSlot` verificável: uma chave nova só passa a existir depois de
+ * entrar na lista, então o compilador recusa um `slotKey("nova")` que o
+ * delete de slot não saberia apagar. Chaves de container são dinâmicas
+ * (`container_<id>`) e varridas pelo prefixo, por isso entram como
+ * template literal em vez de item da lista.
+ */
+export type SlotScopedKey =
+  | (typeof GAME_STATE_KEYS)[number]
+  | `${typeof CONTAINER_KEY_PREFIX}${string}`;
 
 /**
  * Gerencia os slots de save. O backend é injetado no constructor.
@@ -27,11 +43,11 @@ export class SlotManager {
     this.storage.setItem(ACTIVE_SLOT_KEY, String(slot));
   }
 
-  slotKey(key: string): string {
+  slotKey(key: SlotScopedKey): string {
     return this.slotKeyFor(this.getActiveSlot(), key);
   }
 
-  slotKeyFor(slot: SlotIndex, key: string): string {
+  slotKeyFor(slot: SlotIndex, key: SlotScopedKey): string {
     return `${key}_${slot}`;
   }
 
@@ -70,14 +86,15 @@ export class SlotManager {
    * the next save started on that slot. Container keys are not listed:
    * they share the `container_` prefix and are swept separately.
    *
-   * When you add a `slotKey(...)` call site, add its key here too.
+   * `SlotScopedKey` fecha `slotKey()` em cima desta lista, então uma
+   * chave nova não compila antes de entrar aqui.
    */
   clearSlot(slot: SlotIndex) {
     GAME_STATE_KEYS.forEach((key) => {
       this.storage.removeItem(this.slotKeyFor(slot, key));
     });
 
-    const containerPrefix = "container_";
+    const containerPrefix = CONTAINER_KEY_PREFIX;
     const containerSuffix = `_${slot}`;
     const keysToRemove: string[] = [];
     for (let i = 0; i < this.storage.length; i++) {
@@ -131,6 +148,7 @@ export const GAME_STATE_KEYS = [
   "library_return_position",
   "cafeteria_return_position",
   "pet_progress",
+  "profession_progress",
   "jeso_food_last_delivery",
   "char_unlock_dates",
   "difficulty",
@@ -149,8 +167,8 @@ function lazilyResolvedDefaultStorage(): StorageLike {
 
 export const getActiveSlot = () => slotManager.getActiveSlot();
 export const setActiveSlot = (slot: SlotIndex) => slotManager.setActiveSlot(slot);
-export const slotKey = (key: string) => slotManager.slotKey(key);
-export const slotKeyFor = (slot: SlotIndex, key: string) =>
+export const slotKey = (key: SlotScopedKey) => slotManager.slotKey(key);
+export const slotKeyFor = (slot: SlotIndex, key: SlotScopedKey) =>
   slotManager.slotKeyFor(slot, key);
 export const getSlotCount = () => slotManager.getSlotCount();
 export const isSlotUsed = (slot: SlotIndex) => slotManager.isSlotUsed(slot);

--- a/src/utils/types/battle/randomEncounter.ts
+++ b/src/utils/types/battle/randomEncounter.ts
@@ -1,10 +1,12 @@
+import type { SlotScopedKey } from "@/services/save/slotManager";
+
 export type EncounterDef = {
   route: string;
   weight: number;
 };
 
 export type RandomEncounterConfig = {
-  storageKey: string;
+  storageKey: SlotScopedKey;
   blockedTiles?: { x: number; y: number }[];
   encounters: EncounterDef[];
   encounterChance?: number;

--- a/src/utils/types/container.ts
+++ b/src/utils/types/container.ts
@@ -1,3 +1,4 @@
+import type { SlotScopedKey } from "@/services/save/slotManager";
 import type { InventoryItem } from "@/utils/types/player/inventory";
 
 export type ContainerSlot = InventoryItem | null;
@@ -10,5 +11,5 @@ export type ContainerDef = {
   size: number;
   cols: number;
   defaultSlots: ContainerSlots;
-  storageKey: string;
+  storageKey: SlotScopedKey;
 };


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Migração silenciosa de dados: a chave global `rewards` é adotada uma vez para `rewards_<slot>` e removida. Sem perda de progresso, mas o formato no `localStorage` muda.
> - Depois deste PR, criar uma chave nova de save **não compila** enquanto ela não entrar em `GAME_STATE_KEYS`. É intencional.

## Problema

`GAME_STATE_KEYS` é exatamente a lista que o `clearSlot` percorre. A própria docstring já avisava do risco:

> *"a key that is written per slot but missing here survives a deletion and leaks into the next save started on that slot"*

Uma auditoria de todos os call sites de `slotKey()` achou **duas** chaves fora de sincronia:

### `profession_progress` — escrita por slot, ausente da lista

`ProfessionProgressContext` persiste via `useCompressedStorage`, que sempre aplica `slotKey()`. Ou seja, o dado vive em `profession_progress_<slot>`, mas a chave nunca entrou em `GAME_STATE_KEYS`. Apagar o save deixava a proficiência de profissão intacta, e o jogo novo naquele slot herdava tudo.

### `rewards` — listada, mas escrita sem `slotKey()`

`gameRules/rewards/progress.ts` gravava direto em `localStorage.getItem(REWARDS_KEY)`, sem passar pelo slot. Dois efeitos: a chave global sobrevivia ao `clearSlot` (que tentava apagar `rewards_<slot>`, inexistente), e os **dois slots compartilhavam o mesmo progresso de recompensa**.

### A causa comum

`slotKey(key: string)` aceitava qualquer string. Nada ligava o conjunto de chaves realmente usadas ao conjunto de chaves apagadas — a sincronia dependia de alguém lembrar de editar dois arquivos. Foi o que falhou nas duas vezes.

## Solução

### `services/save/slotManager.ts`

- `profession_progress` entra em `GAME_STATE_KEYS`.
- Novo tipo `SlotScopedKey = (typeof GAME_STATE_KEYS)[number] | \`container_${string}\``.
- `slotKey()` e `slotKeyFor()` passam a aceitar `SlotScopedKey` em vez de `string`.
- `CONTAINER_KEY_PREFIX` exportado, para o prefixo do sweep e o do tipo serem literalmente a mesma constante.

Com isso o invariante deixa de ser um comentário e vira erro de compilação: `slotKey("nova_chave")` não compila até `"nova_chave"` estar na lista. Chaves de container continuam dinâmicas (`container_<id>`) e varridas pelo prefixo, então entram no tipo como template literal.

### `gameRules/rewards/progress.ts`

`loadProgress` / `saveProgress` passam a usar `slotKey(REWARDS_KEY)`. Para não zerar quem já jogou, a leitura adota a chave global antiga uma única vez, grava no slot ativo e apaga o legado.

### Propagação do tipo

`useCompressedStorage`, `ContainerDef.storageKey`, `RandomEncounterConfig.storageKey`, `useContainer` e `containerStorageKey()` carregam `SlotScopedKey` até os call sites. Nenhuma mudança de runtime nesses arquivos — só tipo.

### Observação sobre `coins` / `hyperCoins`

As duas continuam em `GAME_STATE_KEYS` mas não têm nenhum call site hoje (moeda vive dentro de `characters_progress`). Foram mantidas de propósito: apagá-las é no-op quando não existem, e remover as entradas deixaria resíduo de saves de versões antigas. Vale uma limpeza separada se confirmarmos que nunca foram escritas em produção.

## Screenshots

**Descrição do Screenshot**: Não se aplica — mudança de persistência, sem alteração visual. A validação foi funcional, inspecionando o `localStorage` no browser (ver "Notas sobre deploy").

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Sem migration de banco. A migração de `rewards` acontece sozinha no primeiro `loadProgress` de cada cliente.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint` nos 7 arquivos tocados → limpo.
- **Playwright MCP**, importando os módulos direto pelo dev server e inspecionando o `localStorage`:

  `clearSlot(0)` com os dois slots populados:

  | chave | antes | depois |
  | --- | --- | --- |
  | `profession_progress_0` | `PROF_SLOT0` | **apagada** |
  | `rewards_0` | `REW_SLOT0` | **apagada** |
  | `container_cafeteria_fridge_0` | `FRIDGE0` | **apagada** |
  | `game_save_0` | `SAVE0` | **apagada** |
  | `profession_progress_1` | `PROF_SLOT1` | intacta |
  | `rewards_1` | `REW_SLOT1` | intacta |
  | `container_cafeteria_fridge_1` | `FRIDGE1` | intacta |

  Migração de `rewards`: com `rewards = {"kill_enemies":42}` e `rewards_0` ausente, `loadProgress()` devolveu `{kill_enemies: 42}`, gravou `rewards_0` e removeu a chave global.
- Reload da aplicação com `localStorage` limpo → sem erro de console.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
