### PR TITLE
fix: não consumir baú, chave e lápide com a mochila cheia

### DIFF
--- a/src/components/Game/Navbar/ExploreNavbar/Inventory/index.tsx
+++ b/src/components/Game/Navbar/ExploreNavbar/Inventory/index.tsx
@@ -1,8 +1,11 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInventory } from "@/contexts/InventoryContext";
 import { useInventoryMenu } from "@/hooks/menu/useInventory";
 import type { FilterConfig } from "@/utils/types/inventory/filterConfig";
-import { useChestOpening } from "@/hooks/chest/useChestOpening";
+import {
+  useChestOpening,
+  type ChestOpenOutcome,
+} from "@/hooks/chest/useChestOpening";
 import { useDailyChest } from "@/hooks/chest/useDailyChest";
 import styles from "./styles.module.css";
 import { ITEMS } from "@/data/items";
@@ -86,9 +89,28 @@ export function Inventory() {
     isDaily: boolean;
   } | null>(null);
 
+  const [popupMessage, setPopupMessage] = useState<string | null>(null);
+  const popupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (popupTimerRef.current) clearTimeout(popupTimerRef.current);
+    };
+  }, []);
+
+  const flashPopup = useCallback((message: string) => {
+    if (popupTimerRef.current) clearTimeout(popupTimerRef.current);
+    setPopupMessage(message);
+    popupTimerRef.current = setTimeout(() => setPopupMessage(null), 2000);
+  }, []);
+
   const handleOpenDailyChest = () => {
-    const result = dailyChest.open();
-    if (result) setOpeningChest({ tier: result.tier, isDaily: true });
+    const outcome = dailyChest.open();
+    if (outcome.status === "opened") {
+      setOpeningChest({ tier: outcome.result.tier, isDaily: true });
+    } else if (outcome.status === "inventoryFull") {
+      flashPopup("Mochila cheia");
+    }
   };
 
   const { selectedIndex, filterFocused, chestFocused } = useInventoryMenu(
@@ -116,16 +138,21 @@ export function Inventory() {
 
   const [rewardOptionIndex, setRewardOptionIndex] = useState(0);
   const [rejectedIndex, setRejectedIndex] = useState<number | null>(null);
-  const [showNoKeyPopup, setShowNoKeyPopup] = useState(false);
+
+  const handleChestOutcome = (outcome: ChestOpenOutcome) => {
+    if (outcome.status === "opened") {
+      setOpeningChest({ tier: outcome.result.tier, isDaily: false });
+    } else if (outcome.status === "inventoryFull") {
+      flashPopup("Mochila cheia");
+    }
+  };
 
   const handleOpenPlayerChest = (id: ItemId) => {
-    const result = openPlayerChest(id);
-    if (result) setOpeningChest({ tier: result.tier, isDaily: false });
+    handleChestOutcome(openPlayerChest(id));
   };
 
   const handleOpenNextChest = (id?: ItemId) => {
-    const result = openNextChest(id);
-    if (result) setOpeningChest({ tier: result.tier, isDaily: false });
+    handleChestOutcome(openNextChest(id));
   };
 
   const hasOtherChest = !!(
@@ -187,10 +214,7 @@ export function Inventory() {
       setRejectedIndex(selectedIndex);
       setTimeout(() => setRejectedIndex(null), 1500);
     },
-    onNoKey: () => {
-      setShowNoKeyPopup(true);
-      setTimeout(() => setShowNoKeyPopup(false), 2000);
-    },
+    onNoKey: () => flashPopup("Sem chave"),
   });
 
   if (openingChest) {
@@ -267,7 +291,9 @@ export function Inventory() {
         )}
       </ul>
 
-      {showNoKeyPopup && <div className={styles.noKeyPopup}>Sem chave</div>}
+      {popupMessage && (
+        <div className={styles.noKeyPopup}>{popupMessage}</div>
+      )}
     </div>
   );
 }

--- a/src/contexts/InventoryContext.tsx
+++ b/src/contexts/InventoryContext.tsx
@@ -21,6 +21,7 @@ type InventoryContextType = {
   addItem: (item: InventoryItem) => boolean;
   removeItem: (id: ItemId) => void;
   hasItem: (id: ItemId) => boolean;
+  hasSpaceFor: (incoming: InventoryItem[]) => boolean;
 
   isOpen: boolean;
   openInventory: () => void;
@@ -89,6 +90,10 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     return items.some((item) => item.id === id);
   }
 
+  function hasSpaceFor(incoming: InventoryItem[]) {
+    return inventoryService.hasSpaceFor(items, incoming);
+  }
+
   return (
     <InventoryContext.Provider
       value={{
@@ -97,6 +102,7 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
         addItem,
         removeItem,
         hasItem,
+        hasSpaceFor,
         isOpen,
         openInventory,
         closeInventory,

--- a/src/hooks/chest/useChestOpening.ts
+++ b/src/hooks/chest/useChestOpening.ts
@@ -15,10 +15,24 @@ export type ChestOpenResult = ChestDropResult & {
   tier: NPCClass;
 };
 
+/**
+ * Desfecho de uma tentativa de abrir baú.
+ *
+ * `inventoryFull` existe porque baú e chave são consumidos na abertura:
+ * sem esse estado, um drop que não coubesse na mochila sumia junto com
+ * os dois itens gastos para obtê-lo.
+ */
+export type ChestOpenOutcome =
+  | { status: "opened"; result: ChestOpenResult }
+  | { status: "unavailable" }
+  | { status: "inventoryFull" };
+
+const UNAVAILABLE: ChestOpenOutcome = { status: "unavailable" };
+
 export function useChestOpening() {
   const { player } = usePlayer();
   const { addDrop } = useEquipment();
-  const { addItem, removeItem, items } = useInventory();
+  const { addItem, removeItem, items, hasSpaceFor } = useInventory();
   const { progressDailyWeekly } = useQuests();
   const { playSound } = useSoundEffects();
   const [lastResult, setLastResult] = useState<ChestOpenResult | null>(null);
@@ -28,18 +42,25 @@ export function useChestOpening() {
   } | null>(null);
 
   const openPlayerChest = useCallback(
-    (chestItemId: ItemId): ChestOpenResult | null => {
-      if (!isChestItem(chestItemId)) return null;
+    (chestItemId: ItemId): ChestOpenOutcome => {
+      if (!isChestItem(chestItemId)) return UNAVAILABLE;
       const chestItem = items.find((i) => i.id === chestItemId);
-      if (!chestItem) return null;
+      if (!chestItem) return UNAVAILABLE;
 
       const tier = CHEST_TIER_BY_ITEM[chestItemId];
       const keyId = getKeyIdForChest(chestItemId);
 
       const keyItem = items.find((i) => i.id === keyId);
-      if (!keyItem) return null;
+      if (!keyItem) return UNAVAILABLE;
 
       const result = openChest(tier);
+
+      const materials = result.materials.map((mat) => ({
+        id: mat.id as ItemId,
+        qty: mat.qty,
+      }));
+
+      if (!hasSpaceFor(materials)) return { status: "inventoryFull" };
 
       for (const mat of result.materials) {
         addItem({ id: mat.id as ItemId, qty: mat.qty });
@@ -64,10 +85,11 @@ export function useChestOpening() {
       const openResult: ChestOpenResult = { ...result, tier };
       setLastResult(openResult);
       setLastOpened({ chestId: chestItemId, keyId });
-      return openResult;
+      return { status: "opened", result: openResult };
     },
     [
       items,
+      hasSpaceFor,
       player.character,
       addDrop,
       addItem,
@@ -89,13 +111,13 @@ export function useChestOpening() {
   );
 
   const openNextChest = useCallback(
-    (excludeChestId?: ItemId) => {
+    (excludeChestId?: ItemId): ChestOpenOutcome => {
       const chest = items.find((i) => {
         if (!isChestItem(i.id) || i.id === excludeChestId) return false;
         const keyId = getKeyIdForChest(i.id);
         return items.some((k) => k.id === keyId);
       });
-      if (!chest) return null;
+      if (!chest) return UNAVAILABLE;
       return openPlayerChest(chest.id);
     },
     [items, openPlayerChest],

--- a/src/hooks/chest/useDailyChest.ts
+++ b/src/hooks/chest/useDailyChest.ts
@@ -29,11 +29,23 @@ export type DailyChestResult = ChestDropResult & {
   tier: NPCClass;
 };
 
+/**
+ * Desfecho de uma tentativa de abrir o baú diário.
+ *
+ * `inventoryFull` bloqueia a abertura antes de gravar o cooldown: sem
+ * isso o jogador queimaria o baú do dia e perderia os materiais que não
+ * couberam na mochila.
+ */
+export type DailyChestOutcome =
+  | { status: "opened"; result: DailyChestResult }
+  | { status: "notReady" }
+  | { status: "inventoryFull" };
+
 export function useDailyChest() {
   const { player } = usePlayer();
   const { progress } = useCharacterProgress();
   const { addDrop } = useEquipment();
-  const { addItem } = useInventory();
+  const { addItem, hasSpaceFor } = useInventory();
   const { progressDailyWeekly } = useQuests();
   const { playSound } = useSoundEffects();
 
@@ -54,11 +66,18 @@ export function useDailyChest() {
 
   const isReady = timeLeft <= 0;
 
-  const open = useCallback(() => {
-    if (!isReady) return null;
+  const open = useCallback((): DailyChestOutcome => {
+    if (!isReady) return { status: "notReady" };
 
     const tier = pickTierForLevel(level);
     const result = openChest(tier, 0.05);
+
+    const materials = result.materials.map((mat) => ({
+      id: mat.id as ItemId,
+      qty: mat.qty,
+    }));
+
+    if (!hasSpaceFor(materials)) return { status: "inventoryFull" };
 
     for (const mat of result.materials) {
       addItem({ id: mat.id as ItemId, qty: mat.qty });
@@ -83,10 +102,11 @@ export function useDailyChest() {
     playSound("chestOpening");
     const openResult: DailyChestResult = { ...result, tier };
     setLastResult(openResult);
-    return openResult;
+    return { status: "opened", result: openResult };
   }, [
     isReady,
     level,
+    hasSpaceFor,
     player.character,
     addItem,
     addDrop,

--- a/src/hooks/tombstone/useSceneTombstones.ts
+++ b/src/hooks/tombstone/useSceneTombstones.ts
@@ -28,7 +28,7 @@ type Params = {
 export function useSceneTombstones({ locationId, onMessage }: Params) {
   const { getTombstones, collectTombstone } = useTombstones();
   const { setBlockedTiles, player } = usePlayer();
-  const { addItem } = useInventory();
+  const { addItem, hasSpaceFor } = useInventory();
   const { addProficiencyXP } = useProfessionProgress();
   const { playSound } = useSoundEffects();
   const hasToolEquipped = useHasToolEquipped();
@@ -64,18 +64,23 @@ export function useSceneTombstones({ locationId, onMessage }: Params) {
       // "um pouco dos drops do npc": re-rolo da tabela de drops do próprio npc
       const rolled = rollCraftDrops(NPCS[npcType].class, npcType);
       const drops = Object.entries(rolled).map(([itemId, qty]) => ({
-        id: itemId,
+        id: itemId as ItemId,
         qty: doubled ? qty * 2 : qty,
       }));
 
-      drops.forEach(({ id, qty }) => addItem({ id: id as ItemId, qty }));
+      if (!hasSpaceFor(drops)) {
+        onMessage?.("Mochila cheia — libere espaço antes de recolher.");
+        return false;
+      }
+
+      drops.forEach(({ id, qty }) => addItem({ id, qty }));
 
       const summary =
         drops
           .map(({ id, qty }) => {
             const name =
               CRAFT_MATERIALS[id as MaterialId]?.name ??
-              ITEMS[id as keyof typeof ITEMS]?.name ??
+              ITEMS[id]?.name ??
               id;
             return `${name} x${qty}`;
           })
@@ -98,6 +103,7 @@ export function useSceneTombstones({ locationId, onMessage }: Params) {
       active,
       hasToolEquipped,
       addItem,
+      hasSpaceFor,
       player.character,
       addProficiencyXP,
       playSound,

--- a/src/services/inventory/inventoryService.ts
+++ b/src/services/inventory/inventoryService.ts
@@ -35,6 +35,27 @@ export class InventoryService {
     return this.maxSlots - this.currencySlots;
   }
 
+  /**
+   * Diz se `incoming` cabe inteiro na mochila.
+   *
+   * Só id que ainda não existe consome slot novo — o resto empilha. Sem
+   * essa checagem prévia, quem entrega vários itens de uma vez (baú,
+   * lápide) descobre o estouro item a item, depois de já ter consumido o
+   * que deu origem ao drop.
+   */
+  hasSpaceFor(items: InventoryItem[], incoming: InventoryItem[]): boolean {
+    const owned = new Set(items.map((i) => i.id));
+    let newSlots = 0;
+
+    for (const item of incoming) {
+      if (owned.has(item.id)) continue;
+      owned.add(item.id);
+      newSlots += 1;
+    }
+
+    return items.length + newSlots <= this.usableSlots;
+  }
+
   addItem(items: InventoryItem[], item: InventoryItem): AddItemResult {
     const existing = items.find((i) => i.id === item.id);
 


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - `useChestOpening.openPlayerChest` / `openNextChest` e `useDailyChest.open` mudaram de assinatura: devolvem um outcome discriminado em vez de `T | null`. Consumidor novo precisa tratar `status`.
> - Conflito esperado com o PR do item 6 (`removed` do `InventoryService`) e com o do item 7 (fila de sons do `InventoryContext`) — os três tocam os mesmos dois arquivos.
> - Achado novo, **fora do escopo deste PR**, ver "Outras mudanças".

## Problema

`InventoryService.addItem` vira no-op quando `items.length >= usableSlots`:

```ts
if (items.length >= this.usableSlots) {
  return { items, added: false, sound: null };
}
```

Ele informa isso pelo retorno — e os três caminhos de drop jogavam o retorno fora:

| Caminho | O que acontecia com a mochila cheia |
| --- | --- |
| `useChestOpening.openPlayerChest` | Materiais sumiam, e `removeItem(chest)` + `removeItem(key)` rodavam mesmo assim. Jogador perdia **baú, chave e drops**. |
| `useDailyChest.open` | Materiais sumiam e o cooldown do dia era gravado. Jogador perdia **o baú diário inteiro**. |
| `useSceneTombstones.collectAt` | Drops sumiam e a lápide era consumida. |

Como `openChest` sorteia de 5 a 11 drops de uma vez, a mochila podia até ter 1 slot livre e ainda assim engolir o resto. Checar item a item não resolve: quando o primeiro `addItem` falha, o baú já foi aberto.

## Solução

### `services/inventory/inventoryService.ts`

Novo método puro `hasSpaceFor(items, incoming)`. Ele conta **só os ids que exigiriam slot novo** — o que já está na mochila empilha e não ocupa nada:

```ts
hasSpaceFor(items: InventoryItem[], incoming: InventoryItem[]): boolean {
  const owned = new Set(items.map((i) => i.id));
  let newSlots = 0;
  for (const item of incoming) {
    if (owned.has(item.id)) continue;
    owned.add(item.id);
    newSlots += 1;
  }
  return items.length + newSlots <= this.usableSlots;
}
```

O `Set` também absorve ids repetidos dentro do próprio `incoming`, que é o caso normal de um baú (o mesmo material pode sair em vários sorteios).

### `contexts/InventoryContext.tsx`

Expõe `hasSpaceFor(incoming)` sobre o estado atual de `items`.

### Os três caminhos de drop

Cada um passa a sortear o loot, checar o espaço de que realmente precisa e **desistir antes de consumir qualquer coisa**.

`useChestOpening` e `useDailyChest` trocam `T | null` por um outcome discriminado, porque o chamador precisa distinguir "não tinha o que abrir" de "não tem espaço":

```ts
export type ChestOpenOutcome =
  | { status: "opened"; result: ChestOpenResult }
  | { status: "unavailable" }
  | { status: "inventoryFull" };
```

Equipamento e pet continuam indo por `addDrop`, que usa outro storage e não tem limite de slot — só os materiais entram na conta.

### UI

O `Inventory` já tinha um popup transitório para "Sem chave". Ele virou `flashPopup(message)`, que também mostra "Mochila cheia", cancela o timer anterior e limpa o timeout no unmount (antes o `setTimeout` não era limpo).

Na lápide, a recusa sai pela mensagem de cena que o hook já recebe: *"Mochila cheia — libere espaço antes de recolher."*

## Screenshots

**Descrição do Screenshot**: Validado no browser com Playwright MCP. Com a mochila em 18/18 slots utilizáveis, clicar em "Abrir" no baú diário mostra o popup "Mochila cheia" (capturado por MutationObserver) e some sozinho em 2s; `daily_chest_last_open_0` continua ausente, e o cabeçalho segue "Baú Diário - Disponível!". O baú comum e a chave permanecem na mochila. Liberando slots, o mesmo botão abre normalmente, exibe a tela de recompensas e grava o cooldown.

## Outras mudanças

- Nenhuma no escopo deste PR.

**Achado novo durante a validação, não corrigido aqui:** abrir um baú cheio de recompensas gera ~180 erros de console `Encountered two children with the same key, 'figurant_totem'`. A causa é independente desta mudança e já existe na `main`: `openChest` faz `result.materials.push(...)` uma vez por sorteio (`data/items/chests.ts:156-175`), então o mesmo material aparece como várias entradas separadas, e a lista de recompensas usa o id como key do React. Merece PR próprio — provavelmente agregando por id no `openChest`.

## Notas sobre deploy

Nenhum passo especial. Sem migration, sem env var.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint` nos 6 arquivos tocados → limpo.
- Playwright MCP, cenário completo descrito em "Screenshots": caminho bloqueado e caminho feliz.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
