### PR TITLE
fix: tratar decremento de pilha como remoção de verdade

### DIFF
--- a/src/services/inventory/inventoryService.ts
+++ b/src/services/inventory/inventoryService.ts
@@ -13,6 +13,7 @@ export type AddItemResult = {
 
 export type RemoveItemResult = {
   items: InventoryItem[];
+  /** true sempre que uma unidade foi consumida, mesmo sobrando pilha. */
   removed: boolean;
   sound: SoundId | null;
 };
@@ -59,6 +60,14 @@ export class InventoryService {
     };
   }
 
+  /**
+   * Consome uma unidade de `id`.
+   *
+   * `removed` reflete o consumo da unidade, não o desaparecimento do
+   * slot: tirar 1 de uma pilha de 3 conta como remoção. Comparar o
+   * tamanho do array antes e depois só enxergava o último item de cada
+   * pilha, então gastar item empilhado não emitia som nenhum.
+   */
   removeItem(items: InventoryItem[], id: ItemId): RemoveItemResult {
     const found = items.find((i) => i.id === id);
     if (!found) {
@@ -73,12 +82,10 @@ export class InventoryService {
       })
       .filter((i): i is InventoryItem => i !== null);
 
-    const removed = next.length < items.length;
-
     return {
       items: next,
-      removed,
-      sound: removed ? "usedItem" : null,
+      removed: true,
+      sound: "usedItem",
     };
   }
 }


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Conflito esperado com o PR do item 5 (`hasSpaceFor`), que toca o mesmo arquivo.
> - Efeito audível: consumir item empilhado passa a tocar o SFX `usedItem`, que hoje é silencioso.

## Problema

`InventoryService.removeItem` decidia se houve remoção comparando o **tamanho do array**:

```ts
const removed = next.length < items.length;

return {
  items: next,
  removed,
  sound: removed ? "usedItem" : null,
};
```

Só que o método remove **uma unidade**, não o slot. Tirar 1 de uma pilha de 3 devolve um array do mesmo tamanho, com `qty: 2` — e aí `removed` volta `false` e o resultado não carrega som.

Na prática: usar qualquer item empilhado era mudo. O SFX `usedItem` só disparava na última unidade, quando o slot finalmente sumia. Como poção, comida e energético são exatamente os itens que o jogador acumula, o caso silencioso é o comum e o caso sonoro é a exceção.

`removed` também é o campo que qualquer consumidor futuro leria para saber se o consumo valeu — devolver `false` depois de ter decrementado é resposta errada, independente do som.

## Solução

O early return no topo já cobre "item não está na mochila". Passado dele, uma unidade sempre foi consumida:

```ts
const found = items.find((i) => i.id === id);
if (!found) {
  return { items, removed: false, sound: null };
}
// ...
return { items: next, removed: true, sound: "usedItem" };
```

Docstring no método e no campo `removed` do `RemoveItemResult` registram que a semântica é "unidade consumida", não "slot esvaziado" — que é justamente a confusão que gerou o bug.

## Screenshots

**Descrição do Screenshot**: Não se aplica — regra pura, sem alteração visual. A diferença perceptível é sonora, validada por teste direto do service (ver "Notas sobre deploy").

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Nenhum passo especial.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint src/services/inventory/inventoryService.ts` → limpo.
- Service exercitado direto no browser via Playwright MCP:

  | caso | `items` resultante | `removed` | `sound` |
  | --- | --- | --- | --- |
  | pilha de 3 → 2 | `[{orange_juice, qty: 2}]` | `true` | `usedItem` |
  | última unidade | `[]` | `true` | `usedItem` |
  | id fora da mochila | inalterado | `false` | `null` |

  Antes da mudança, a primeira linha devolvia `removed: false` e `sound: null`.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
