### PR TITLE
fix: acumular a fila de sons do inventário em vez de sobrescrever

### DIFF
--- a/src/contexts/InventoryContext.tsx
+++ b/src/contexts/InventoryContext.tsx
@@ -10,7 +10,6 @@ import {
 import type { InventoryItem } from "@/utils/types/player/inventory";
 import { useSoundEffects, type SoundId } from "@/contexts/SoundEffectsContext";
 import { INVENTORY_KEY } from "@/data/storageKeys";
-import { useLatestRef } from "@/hooks/useLatestRef";
 import { useCompressedStorage } from "@/hooks/useCompressedStorage";
 import { useToggle } from "@/hooks/useToggle";
 import { InventoryService } from "@/services/inventory";
@@ -48,14 +47,25 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
   } = useToggle();
 
   const [maxSlots, setMaxSlots] = useState(20);
-  const maxSlotsRef = useLatestRef(maxSlots);
 
   const inventoryService = useMemo(
     () => new InventoryService(maxSlots),
     [maxSlots],
   );
-  // serviço com capacidade fresca para uso dentro de updaters
-  const freshService = () => new InventoryService(maxSlotsRef.current);
+
+  /**
+   * Array mais recente da mochila, incluindo mutações desta mesma tick
+   * que o `items` do render ainda não enxerga.
+   *
+   * Ele existe para que a regra rode fora do updater do `setItems`. Um
+   * updater precisa ser puro: o React pode reexecutá-lo (StrictMode em
+   * dev reexecuta sempre), então enfileirar som lá dentro duplica ou
+   * perde evento. Com o ref carregando o resultado adiante, chamadas
+   * encadeadas no mesmo tick — vários `addItem` de um baú, por exemplo —
+   * continuam enxergando umas às outras.
+   */
+  const latestItemsRef = useRef(items);
+  latestItemsRef.current = items;
 
   const pendingSoundsRef = useRef<SoundId[]>([]);
 
@@ -64,25 +74,21 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     sounds.forEach((s) => playSound(s));
   }, [items, playSound]);
 
+  function commit(next: InventoryItem[], sound: SoundId | null) {
+    latestItemsRef.current = next;
+    if (sound) pendingSoundsRef.current.push(sound);
+    setItems(next);
+  }
+
   function addItem(item: InventoryItem): boolean {
-    // retorno baseado no estado atual do render (semântica legada)
-    const { added } = inventoryService.addItem(items, item);
-
-    setItems((prev) => {
-      const result = freshService().addItem(prev, item);
-      pendingSoundsRef.current = result.sound ? [result.sound] : [];
-      return result.items;
-    });
-
-    return added;
+    const result = inventoryService.addItem(latestItemsRef.current, item);
+    commit(result.items, result.sound);
+    return result.added;
   }
 
   function removeItem(id: ItemId) {
-    setItems((prev) => {
-      const result = freshService().removeItem(prev, id);
-      pendingSoundsRef.current = result.sound ? [result.sound] : [];
-      return result.items;
-    });
+    const result = inventoryService.removeItem(latestItemsRef.current, id);
+    commit(result.items, result.sound);
   }
 
   function hasItem(id: ItemId) {


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Conflito esperado com os PRs dos itens 5 e 6, que tocam `InventoryContext.tsx` / `InventoryService`.
> - `addItem` continua devolvendo `boolean`, mas agora o valor é o real da operação aplicada, não o do snapshot do render. Nenhum call site lê esse retorno hoje.

## Problema

`addItem` e `removeItem` enfileiravam o som **de dentro do updater do `setItems`**, e enfileiravam **substituindo** a fila:

```ts
setItems((prev) => {
  const result = freshService().addItem(prev, item);
  pendingSoundsRef.current = result.sound ? [result.sound] : [];
  return result.items;
});
```

São dois defeitos empilhados.

**1. A fila só guardava a última operação do lote.** Um baú que entrega seis materiais chama `addItem` seis vezes no mesmo tick; cada chamada apagava a anterior e sobrava um único `receivedItem`. Pior: uma sequência `addItem` + `removeItem` no mesmo lote (abrir baú consome baú e chave) descartava um dos dois sons conforme a ordem.

**2. Updater de estado tem que ser puro.** O React pode reexecutar o updater, e o StrictMode reexecuta **sempre** em dev. Enfileirar efeito lá dentro é incorreto de qualquer jeito — com `=` você perde evento, e trocar para `push` faria o StrictMode duplicar. Não dá para consertar mantendo o efeito no updater. É também a primeira regra da seção "Regras Importantes" do `AGENTS.md`: *"Não colocar side effects dentro de state updaters"*.

O updater existia por um motivo legítimo: `prev` é o único jeito de chamadas encadeadas no mesmo tick enxergarem umas às outras. Qualquer correção precisa preservar isso.

## Solução

Tirar a regra de dentro do updater e dar a ela outra fonte de "estado mais recente":

```ts
const latestItemsRef = useRef(items);
latestItemsRef.current = items;          // re-sincroniza a cada render

function commit(next: InventoryItem[], sound: SoundId | null) {
  latestItemsRef.current = next;         // encadeamento no mesmo tick
  if (sound) pendingSoundsRef.current.push(sound);
  setItems(next);
}
```

- `latestItemsRef` carrega o array adiante dentro do tick, então os seis `addItem` do baú continuam se enxergando — mesmo papel que o `prev` fazia.
- O updater some: `setItems` recebe valor pronto.
- A fila de sons passa a acumular (`push`), fora de qualquer updater, então nem se perde evento nem se duplica sob StrictMode.
- `freshService()` deixa de ser necessário: `inventoryService` já é memoizado por `maxSlots` e é lido no momento da chamada, não dentro de um updater diferido.

`addItem` passa a devolver o `added` da operação que realmente aplicou, em vez do calculado sobre o `items` do render (a "semântica legada" que o comentário anterior admitia). Nenhum consumidor lê esse booleano hoje.

`setItems` continua exportado e é usado pelo `App` para carregar save da nuvem/local; como é substituição completa seguida de render, o ref re-sincroniza normalmente.

## Screenshots

**Descrição do Screenshot**: Não se aplica — sem mudança visual. A diferença é sonora, medida contando chamadas de `HTMLMediaElement.play` (ver "Notas sobre deploy").

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Nenhum passo especial.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint src/contexts/InventoryContext.tsx` → limpo.
- **A/B no browser com Playwright MCP**, abrindo o baú diário com a mochila vazia e um spy em `HTMLMediaElement.prototype.play`:

  | | drops de material no sorteio | `receivedAnItem` tocados | mochila resultante |
  | --- | --- | --- | --- |
  | Código da `main` | 6 | **1** | correta (3 pilhas) |
  | Com o fix | 4 | **4** | correta (3 pilhas) |

  O conteúdo da mochila sai certo nos dois casos — o que se perdia era só o som. A proporção 1-para-N confirma que a fila acumula em vez de ser sobrescrita.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
