### PR TITLE
refactor: marcar payload comprimido em vez de adivinhar o formato

### DIFF
--- a/src/services/save/storageService.ts
+++ b/src/services/save/storageService.ts
@@ -10,6 +10,16 @@ export type StorageLike = {
 };
 
 /**
+ * Marca todo payload comprimido escrito por esta versão.
+ *
+ * Sem ela, a leitura tinha que adivinhar o formato pelo primeiro
+ * caractere — e `compressToUTF16` emite code points a partir de 32, o
+ * que inclui `[` (91) e `{` (123). Um payload comprimido podia começar
+ * com um deles e ser lido como JSON.
+ */
+const COMPRESSED_PREFIX = "lz1:";
+
+/**
  * Persistência comprimida em KV. O backend é injetado no constructor —
  * em produção é o localStorage; em testes pode ser um Map.
  */
@@ -24,32 +34,52 @@ export class StorageService {
     try {
       const json = JSON.stringify(data);
       const compressed = LZString.compressToUTF16(json);
-      this.backend.setItem(key, compressed);
+      this.backend.setItem(key, COMPRESSED_PREFIX + compressed);
     } catch {
       this.backend.setItem(key, JSON.stringify(data));
     }
   }
 
+  /**
+   * Lê `key`, aceitando os três formatos que podem estar gravados.
+   *
+   * Payload novo carrega `COMPRESSED_PREFIX` e é decidido sem
+   * ambiguidade. Sem o prefixo, o valor veio de uma versão anterior e o
+   * formato precisa ser adivinhado — mas aí cada palpite tem o outro
+   * como alternativa, em vez de a falha do primeiro derrubar a leitura
+   * inteira. Era esse o caminho que perdia save: um payload comprimido
+   * começando com `[` ou `{` ia para o `JSON.parse`, estourava, e o
+   * fallback tentava exatamente o mesmo parse de novo.
+   */
   loadCompressed<T>(key: string): T | null {
+    const raw = this.backend.getItem(key);
+    if (!raw) return null;
+
+    if (raw.startsWith(COMPRESSED_PREFIX)) {
+      return this.decompress<T>(raw.slice(COMPRESSED_PREFIX.length));
+    }
+
+    if (raw.startsWith("[") || raw.startsWith("{")) {
+      return this.parse<T>(raw) ?? this.decompress<T>(raw);
+    }
+
+    return this.decompress<T>(raw) ?? this.parse<T>(raw);
+  }
+
+  private parse<T>(json: string): T | null {
     try {
-      const raw = this.backend.getItem(key);
-      if (!raw) return null;
-
-      if (raw.startsWith("[") || raw.startsWith("{")) {
-        return JSON.parse(raw) as T;
-      }
-
-      const json = LZString.decompressFromUTF16(raw);
-      if (!json) return null;
       return JSON.parse(json) as T;
     } catch {
-      try {
-        const raw = this.backend.getItem(key);
-        if (!raw) return null;
-        return JSON.parse(raw) as T;
-      } catch {
-        return null;
-      }
+      return null;
+    }
+  }
+
+  private decompress<T>(payload: string): T | null {
+    try {
+      const json = LZString.decompressFromUTF16(payload);
+      return json ? this.parse<T>(json) : null;
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - **Correção de premissa:** o bug que originou este item **não se confirma**. Ver "Problema". Este PR virou endurecimento + remoção de código morto, e é legítimo rejeitar a parte do sentinela.
> - Muda o formato gravado no `localStorage` (passa a ter o prefixo `lz1:`). A leitura continua aceitando o formato antigo, então é retrocompatível — mas é mudança de persistência e merece atenção na revisão.
> - Conflito esperado com o PR do item 8, que toca o mesmo método.

## Problema

### O que eu havia reportado, e que está errado

Reportei que `loadCompressed` podia perder save porque decide o formato pelo primeiro caractere:

```ts
if (raw.startsWith("[") || raw.startsWith("{")) {
  return JSON.parse(raw) as T;
}
```

O raciocínio era: `compressToUTF16` emite code points a partir de 32, então `[` (91) e `{` (123) estão no alcance e um payload comprimido poderia começar com um deles.

**A medição não sustenta isso.** O primeiro caractere da saída deriva do primeiro caractere da entrada, e para JSON ele cai na faixa 7010–7138:

| entrada | primeiro code point da saída |
| --- | --- |
| `{"a":1}` | 7137 |
| `[1,2,3]` | 7010 |
| `[{"id":"orange_juice"...}]` | 7011 |

Varri 400.000 payloads variados e todos os 95 primeiros-bytes ASCII possíveis: **nenhuma saída começa com `[` ou `{`**. A colisão não é alcançável hoje. Peço desculpas pelo diagnóstico errado.

### O que sobra de real

O `catch` aninhado é **código morto em todos os caminhos**:

```ts
} catch {
  try {
    const raw = this.backend.getItem(key);
    if (!raw) return null;
    return JSON.parse(raw) as T;   // mesmo parse que acabou de falhar
  } catch { return null; }
}
```

- Se o `raw` era JSON e o parse falhou (valor truncado), o fallback repete o **mesmo** `JSON.parse` na **mesma** string. Falha de novo.
- Se o `raw` era comprimido e o `JSON.parse(json)` falhou, o fallback tenta `JSON.parse` no **texto comprimido**. Falha de novo.

Nunca recupera nada. É ruído que dá aparência de resiliência.

## Solução

### Sentinela (endurecimento, não correção de bug)

Todo payload comprimido passa a ser gravado com o prefixo `lz1:`, e a leitura decide por ele em vez de adivinhar. Valor sem prefixo veio de versão anterior e continua passando pela heurística.

O ganho é de futuro: hoje a heurística só é segura por um acidente do empacotamento de bits do `compressToUTF16`. Trocar o encoder (`compress`, base64, outra lib) reintroduziria a ambiguidade em silêncio. Com o sentinela, o formato é declarado em vez de inferido.

**Se o revisor preferir não mexer no formato de persistência agora, dá para mergear só a segunda parte.**

### Fallback morto → alternativa de verdade

`parse()` e `decompress()` viraram helpers privados que devolvem `null` em vez de lançar, e cada palpite do caminho legado tem o outro como alternativa real:

```ts
if (raw.startsWith("[") || raw.startsWith("{")) {
  return this.parse<T>(raw) ?? this.decompress<T>(raw);
}
return this.decompress<T>(raw) ?? this.parse<T>(raw);
```

Isso sim é recuperação: o segundo palpite é diferente do primeiro.

## Screenshots

**Descrição do Screenshot**: Não se aplica — camada de persistência, sem alteração visual.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Sem migration. Save antigo é lido normalmente e passa a ser gravado com prefixo na próxima escrita.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint src/services/save/storageService.ts` → limpo.
- Análise do encoder em Node com `lz-string` (dados na seção "Problema").
- Service exercitado no browser via Playwright MCP com backend injetado:

  | valor gravado | leitura |
  | --- | --- |
  | escrito por esta versão | prefixo `lz1:` presente, round trip ok |
  | JSON cru legado (sem prefixo) | lido corretamente |
  | comprimido legado (sem prefixo) | lido corretamente |
  | lixo binário | `null`, sem exceção |
  | JSON truncado | `null`, sem exceção |
  | chave ausente | `null` |

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
