### PR TITLE
fix: invalidar os stats de batalha quando o equipamento muda

### DIFF
--- a/src/contexts/EquipmentContext.tsx
+++ b/src/contexts/EquipmentContext.tsx
@@ -30,6 +30,15 @@ import {
 } from "@/gameRules/equipment/operations";
 
 type EquipmentContextType = {
+  /**
+   * Token opaco que troca de identidade a cada mutação de equipamento.
+   *
+   * Existe para quem lê equipamento por função que vai ao storage em vez
+   * de pelo estado do contexto (`gameRules/battle/equipment`): sem uma
+   * dependência que mude, o `useMemo` desses consumidores nunca invalida
+   * e o resultado congela até o personagem trocar.
+   */
+  equipmentRevision: object;
   getEquippedItem: (
     character: CharacterId,
     slot: EquipmentSlot,
@@ -232,6 +241,7 @@ export function EquipmentProvider({ children }: { children: ReactNode }) {
   return (
     <EquipmentContext.Provider
       value={{
+        equipmentRevision: allData,
         getEquippedItem,
         getEquippedInfo,
         getEquippedAccessories,

--- a/src/hooks/battle/useStats.ts
+++ b/src/hooks/battle/useStats.ts
@@ -7,9 +7,6 @@ import {
   getEquipmentStatsBonus,
   getWeaponCritRate,
   getTotalArmor,
-  getTotalShield,
-  getTotalVampirism,
-  getTotalReflect,
 } from "@/gameRules/battle/equipment";
 import { getTenacityReduction } from "@/gameRules/battle/tenacity";
 import { getNpcStats } from "@/gameRules/npc/npcStats";
@@ -71,6 +68,20 @@ type Props = {
   npcArmorBonus?: number;
 };
 
+/**
+ * Consolida os stats usados na batalha: personagem, equipamento, título,
+ * ranque e os stats do NPC.
+ *
+ * A leitura de equipamento é um memo só, dependente de
+ * `equipmentRevision`. `getEquipmentStatsBonus` e companhia vão ao
+ * storage por dentro em vez de ler o estado do contexto, então o
+ * exhaustive-deps não enxerga essa dependência — daí o token explícito e
+ * o disable. Sem ele nada invalidava, e equipar ou desequipar sem trocar
+ * de personagem deixava a batalha rodando com os stats antigos.
+ *
+ * Escudo, vampirismo e reflexo saem do mesmo `bonus`: `getTotalShield` e
+ * companhia recarregavam o storage para recalcular número idêntico.
+ */
 export function useBattleStats({
   npcLevel,
   npcClass,
@@ -82,40 +93,31 @@ export function useBattleStats({
   const { player, playerClass } = usePlayer();
   const { progress } = useCharacterProgress();
   const { getBonus, getElementDamageBonus } = useTitles();
-  const { getEquippedItem } = useEquipment();
+  const { getEquippedItem, equipmentRevision } = useEquipment();
 
   const baseChar = progress[player.character];
 
-  const equipmentBonus = useMemo(() => {
-    return getEquipmentStatsBonus(player.character);
-  }, [player.character]);
+  const equipment = useMemo(
+    () => ({
+      bonus: getEquipmentStatsBonus(player.character),
+      weaponCritRate: getWeaponCritRate(player.character),
+      armor: getTotalArmor(player.character, baseChar.stats.resistance),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [player.character, baseChar.stats.resistance, equipmentRevision],
+  );
 
-  const weaponCritRate = useMemo(() => {
-    return getWeaponCritRate(player.character);
-  }, [player.character]);
+  const equipmentBonus = equipment.bonus;
+  const weaponCritRate = equipment.weaponCritRate;
 
   const titleBonus = useMemo(() => {
     return getBonus();
   }, [getBonus]);
 
-  const totalArmor = useMemo(() => {
-    return (
-      getTotalArmor(player.character, baseChar.stats.resistance) +
-      titleBonus.armor
-    );
-  }, [player.character, baseChar.stats.resistance, titleBonus.armor]);
-
-  const totalShield = useMemo(() => {
-    return getTotalShield(player.character) + titleBonus.shield;
-  }, [player.character, titleBonus.shield]);
-
-  const totalVampirism = useMemo(() => {
-    return getTotalVampirism(player.character);
-  }, [player.character]);
-
-  const totalReflect = useMemo(() => {
-    return getTotalReflect(player.character);
-  }, [player.character]);
+  const totalArmor = equipment.armor + titleBonus.armor;
+  const totalShield = equipmentBonus.shield + titleBonus.shield;
+  const totalVampirism = equipmentBonus.vampirism;
+  const totalReflect = equipmentBonus.reflect;
 
   const totalMaxHpDamage = useMemo(() => {
     return equipmentBonus.maxHpDamage ?? 0;


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - **Severidade real menor do que eu reportei:** a leitura obsoleta é **latente**, não visível para o jogador hoje. Detalhe abaixo.
> - Novo campo `equipmentRevision` no `EquipmentContext`. É token opaco; não leia o conteúdo dele.

## Problema

`useBattleStats` memoizava seis leituras de equipamento em `[player.character]`:

```ts
const equipmentBonus = useMemo(() => {
  return getEquipmentStatsBonus(player.character);
}, [player.character]);
```

Só que essas funções **não leem o estado do contexto**. `getEquipmentStatsBonus`, `getWeaponCritRate` e `getTotalArmor` chamam `loadEquipped()` por dentro, que vai ao `localStorage`. O equipamento pode mudar sem que nenhuma dependência mude, e o memo continua servindo o número antigo até o personagem trocar.

O `exhaustive-deps` não acusa porque a dependência é alcançada via storage — está fora do que o lint consegue enxergar.

### Quão grave é, na prática

Fui checar o alcance antes de escrever o fix, e ele é menor do que eu disse no relatório:

- `useBattleStats` só é usado pelo `useSystem`, ou seja, só na página de batalha.
- Nada equipa ou desequipa com a batalha montada — a `BattleNavbar` tem `BattleInventory`, `Characters` e `Settings`, não tela de equipamento.
- Os `addDrop` que rodam na recompensa mexem só na **coleção**, não nos slots equipados, então não mudam stat nenhum.
- Troca de personagem na derrota passa por `setCharacter`, que já está nas deps.

Ou seja: **dependência errada e latente**, não bug que o jogador sente hoje. O que é concreto e mensurável é a redundância descrita abaixo.

## Solução

### `contexts/EquipmentContext.tsx`

Novo `equipmentRevision: object`, ligado ao `allData` do provider. Toda mutação reconstrói esse objeto (`getMutableState` faz `{ ...allData }`), então o token troca de identidade exatamente quando o equipamento muda. Tipado como `object` de propósito: é para ser usado como dependência, não lido.

### `hooks/battle/useStats.ts`

As seis leituras viram **uma**:

```ts
const equipment = useMemo(
  () => ({
    bonus: getEquipmentStatsBonus(player.character),
    weaponCritRate: getWeaponCritRate(player.character),
    armor: getTotalArmor(player.character, baseChar.stats.resistance),
  }),
  // eslint-disable-next-line react-hooks/exhaustive-deps
  [player.character, baseChar.stats.resistance, equipmentRevision],
);
```

`getTotalShield`, `getTotalVampirism` e `getTotalReflect` foram removidos: os três recarregavam o storage para recalcular número que `getEquipmentStatsBonus` **já devolve** no mesmo objeto. Agora saem de `equipmentBonus.shield` / `.vampirism` / `.reflect`.

Um `eslint-disable` em vez de seis, e a docstring do hook registra o motivo — pragma de lint é a exceção prevista à regra de "zero comentário inline".

## Screenshots

**Descrição do Screenshot**: Não se aplica — sem mudança visual. Validação numérica e de contagem de I/O abaixo.

## Outras mudanças

- Nenhuma.

**Não corrigido de propósito:** `useRegenTimer` chama `getEquipmentStatsBonus` dentro de um effect cujas deps não incluem equipamento. Não vale mexer: as deps incluem `progress`, que o próprio regen reescreve a cada segundo, então o valor se corrige sozinho em ~1s.

## Notas sobre deploy

Nenhum passo especial.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint src/hooks/battle/useStats.ts src/contexts/EquipmentContext.tsx` → limpo, zero warning.
- **Equivalência dos três valores derivados**, no browser via Playwright MCP, com um loadout de valores não-zero (coroa do rei +5, espada do rei +4, calça do rei +2, dois anéis):

  | stat | `getTotal*` (antes) | `bonus.*` (depois) |
  | --- | --- | --- |
  | shield | 26 | 26 |
  | vampirism | 1 | 1 |
  | reflect | 6 | 6 |

- **Contagem de I/O**, instrumentando `Storage.prototype.getItem` na chave `jomasio_equipment_0`, para uma invalidação:

  | | leituras do storage |
  | --- | --- |
  | conjunto antigo (6 funções) | **11** |
  | conjunto novo (3 funções) | **5** |

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
