### PR TITLE
fix: derivar a tabela de desvantagem elemental da tabela de vantagem

### DIFF
--- a/ELEMENTS.md
+++ b/ELEMENTS.md
@@ -151,3 +151,51 @@ Cada npc e personagem tem pelo menos um e no máximo 2 tipagens
 por exemplo:
 O personagem Marshadow é normalis e ventus
 O npc leviathan é aquos e draco
+
+---
+
+## Como o código resolve a tabela
+
+As duas listas acima ("Forte contra" / "Fraco contra") não se encaixavam:
+em sete elementos, a lista de "fraco" não era o inverso da lista de
+"forte", e em seis pares o mesmo elemento aparecia nos dois lados sem que
+nada dissesse qual valia.
+
+Para não ter mais como divergir, `src/data/types/elementChart.ts` mantém
+**só a tabela de vantagem escrita à mão**. A desvantagem é gerada como o
+inverso exato dela: se `A` é forte contra `D`, então `D` é fraco contra
+`A`.
+
+Isso muda a leitura de "Fraco contra" de sete elementos em relação ao texto
+acima. A tabela que vale é esta:
+
+| Elemento | Forte contra | Fraco contra (derivado) |
+| --- | --- | --- |
+| Pyrus | Metallum, Natura | Aquos, Subterra |
+| Aquos | Pyrus, Subterra | Electricus, Natura |
+| Subterra | Pyrus, Electricus, Metallum | Aquos, Ventus, Natura |
+| Ventus | Subterra, Natura | Electricus, Metallum |
+| Darkus | Haos, Nympha, Umbra, Psychicus | Haos, Nympha, Umbra |
+| Electricus | Aquos, Ventus, Natura | Subterra, Metallum |
+| Haos | Darkus, Umbra | Darkus, Metallum, Nympha, Umbra |
+| Metallum | Ventus, Haos, Electricus | Pyrus, Subterra |
+| Natura | Aquos, Subterra | Pyrus, Ventus, Electricus |
+| Psychicus | Umbra, Normalis | Darkus, Umbra |
+| Nympha | Darkus, Haos, Draco | Darkus, Umbra |
+| Draco | Draco, Normalis | Nympha, Draco |
+| Umbra | Darkus, Haos, Psychicus, Nympha | Darkus, Haos, Psychicus |
+| Normalis | — | Psychicus, Draco |
+
+Para mudar qualquer relação, edite **só** `ELEMENT_STRONG_AGAINST`. A coluna
+da direita se ajusta sozinha.
+
+Derivar não faz sumir todo par que cai nos dois lados: **vantagem mútua
+continua existindo**. Darkus é forte contra Haos e Haos é forte contra
+Darkus, então cada um aparece na lista de "fraco" do outro. Hoje há 11
+pares assim, e `getElementMultiplier` testa vantagem antes de
+desvantagem — todos resolvem **1.5x nas duas direções**.
+
+A diferença é que isso virou consequência declarada da tabela de
+vantagem, em vez de acidente de duas listas desencontradas. Se a intenção
+for que opostos se anulem (1x), a mudança é em `CombatService`, não
+aqui.

--- a/src/data/types/elementChart.ts
+++ b/src/data/types/elementChart.ts
@@ -20,20 +20,51 @@ export const ELEMENT_STRONG_AGAINST: Record<
   Normalis: [],
 };
 
+/**
+ * Inverte a tabela de vantagem: `A` forte contra `D` significa `D` fraco
+ * contra `A`.
+ *
+ * Args:
+ *     strong (Record<ElementType, readonly ElementType[]>): tabela de
+ *         vantagem, atacante para defensores.
+ *
+ * Returns:
+ *     A tabela de desvantagem correspondente, com entrada para todo
+ *     elemento (lista vazia quando ninguém tem vantagem sobre ele).
+ */
+function buildWeakAgainst(
+  strong: Record<ElementType, readonly ElementType[]>,
+): Record<ElementType, readonly ElementType[]> {
+  const weak = {} as Record<ElementType, ElementType[]>;
+
+  for (const element of Object.keys(strong) as ElementType[]) {
+    weak[element] = [];
+  }
+
+  for (const element of Object.keys(strong) as ElementType[]) {
+    for (const defender of strong[element]) {
+      weak[defender].push(element);
+    }
+  }
+
+  return weak;
+}
+
+/**
+ * Desvantagem elemental, derivada de `ELEMENT_STRONG_AGAINST`.
+ *
+ * As duas tabelas eram escritas à mão e divergiam: em sete elementos a
+ * lista de desvantagem não batia com o inverso da lista de vantagem, e
+ * em seis pares o mesmo defensor aparecia nas duas listas do mesmo
+ * atacante sem que nada no dado dissesse qual valia.
+ *
+ * Derivar acaba com a divergência arbitrária, não com todo par que cai
+ * nos dois lados. Vantagem mútua continua existindo — Darkus e Haos são
+ * fortes um contra o outro por design, e `getElementMultiplier` testa
+ * vantagem antes de desvantagem, então esses pares resolvem 1.5x nas
+ * duas direções. A diferença é que agora isso é consequência declarada
+ * do `ELEMENT_STRONG_AGAINST`, e não de duas tabelas que se
+ * desencontraram.
+ */
 export const ELEMENT_WEAK_AGAINST: Record<ElementType, readonly ElementType[]> =
-  {
-    Pyrus: ["Aquos", "Subterra"],
-    Aquos: ["Electricus", "Natura"],
-    Subterra: ["Ventus", "Natura", "Aquos"],
-    Ventus: ["Electricus", "Metallum"],
-    Darkus: ["Haos", "Nympha", "Umbra"],
-    Electricus: ["Subterra", "Metallum"],
-    Haos: ["Darkus", "Umbra"],
-    Metallum: ["Pyrus", "Subterra"],
-    Natura: ["Pyrus", "Ventus", "Metallum"],
-    Psychicus: ["Darkus", "Haos"],
-    Nympha: ["Ventus", "Metallum", "Umbra"],
-    Draco: ["Haos", "Natura", "Nympha", "Draco"],
-    Umbra: ["Ventus", "Umbra"],
-    Normalis: ["Psychicus"],
-  };
+  buildWeakAgainst(ELEMENT_STRONG_AGAINST);


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - **Mudança de balanceamento.** A leitura de "fraco contra" muda para 7 dos 14 elementos. Tabela completa do antes/depois abaixo.
> - Opção escolhida entre as três que apresentei: derivar `WEAK` de `STRONG`.
> - `ELEMENTS.md` foi atualizado com uma seção nova no fim; o texto de design original está preservado.

## Problema

`ELEMENT_STRONG_AGAINST` e `ELEMENT_WEAK_AGAINST` eram duas tabelas escritas à mão, e elas não fechavam entre si.

**Divergência:** em 7 elementos a lista de "fraco" não era o inverso da lista de "forte". Exemplo: `Metallum` é forte contra `Haos`, mas `Haos` não listava `Metallum` como fraqueza.

**Ambiguidade:** em 6 pares o mesmo defensor aparecia nas **duas** listas do mesmo atacante — `Darkus` contra Haos/Nympha/Umbra, `Haos` contra Darkus/Umbra, `Draco` contra `Draco`. O dado não dizia qual valia. Quem decidia era o `if/else if`:

```ts
if (ELEMENT_STRONG_AGAINST[attacker].includes(defender)) {
  multiplier *= this.superEffectiveMultiplier;
} else if (ELEMENT_WEAK_AGAINST[attacker].includes(defender)) {
  multiplier *= this.notVeryEffectiveMultiplier;
}
```

"Forte" sempre ganhava, então essas entradas de "fraco" eram código morto — e ninguém lendo só a tabela saberia disso.

## Solução

`ELEMENT_STRONG_AGAINST` continua sendo a única tabela escrita à mão. `ELEMENT_WEAK_AGAINST` passa a ser gerada como o **inverso exato** dela: se `A` é forte contra `D`, então `D` é fraco contra `A`.

```ts
export const ELEMENT_WEAK_AGAINST: Record<ElementType, readonly ElementType[]> =
  buildWeakAgainst(ELEMENT_STRONG_AGAINST);
```

Para mudar qualquer relação daqui em diante, edita-se **um** lugar.

### O que muda no balanceamento

| Elemento | Fraco contra (antes) | Fraco contra (depois) |
| --- | --- | --- |
| Pyrus | Aquos, Subterra | *(igual)* |
| Aquos | Electricus, Natura | *(igual)* |
| Subterra | Ventus, Natura, Aquos | *(igual)* |
| Ventus | Electricus, Metallum | *(igual)* |
| Darkus | Haos, Nympha, Umbra | *(igual)* |
| Electricus | Subterra, Metallum | *(igual)* |
| Metallum | Pyrus, Subterra | *(igual)* |
| **Haos** | Darkus, Umbra | Darkus, **Metallum**, **Nympha**, Umbra |
| **Natura** | Pyrus, Ventus, Metallum | Pyrus, Ventus, **Electricus** |
| **Psychicus** | Darkus, Haos | Darkus, **Umbra** |
| **Nympha** | Ventus, Metallum, Umbra | **Darkus**, Umbra |
| **Draco** | Haos, Natura, Nympha, Draco | Nympha, Draco |
| **Umbra** | Ventus, Umbra | **Darkus**, **Haos**, **Psychicus** |
| **Normalis** | Psychicus | Psychicus, **Draco** |

Vale notar que `Draco` **ganha** resistência (perde Haos e Natura como fraqueza), o que combina com a intenção declarada no `ELEMENTS.md` de ser "tipo poderoso, com poucos counters".

### Uma correção ao que eu havia dito

Ao validar, medi uma coisa que contraria o que afirmei no relatório: **derivar não faz sumir todo par que cai nos dois lados**. Vantagem mútua continua existindo por construção — Darkus é forte contra Haos *e* Haos é forte contra Darkus, então cada um aparece na lista de "fraco" do outro. Hoje são **11 pares assim**, e todos resolvem **1.5x nas duas direções**, porque vantagem é testada antes de desvantagem.

O que a derivação elimina é a divergência *arbitrária*. Um par mútuo agora é consequência declarada da tabela de vantagem, não acidente de duas listas desencontradas. Se a intenção for que opostos se anulem (1x), isso é mudança no `CombatService`, não na tabela — deixei isso registrado no `ELEMENTS.md`.

## Screenshots

**Descrição do Screenshot**: Não se aplica — tabela de dados. Existe um item no `TODO.md` para exibir essa tabela na Tab de batalha das configurações; quando ela for feita, vai ler diretamente destas duas constantes.

## Outras mudanças

- `ELEMENTS.md`: seção nova no fim documentando que o código deriva a tabela, com o resultado final e a nota sobre vantagem mútua. O texto de design original ficou intacto.

## Notas sobre deploy

Nenhum passo especial. Nada persistido muda.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint src/data/types/elementChart.ts` → limpo.
- Tabela construída verificada no browser via Playwright MCP:
  - `WEAK` é o inverso exato de `STRONG` para os 14 elementos → **true**;
  - todo elemento tem entrada (nenhum `undefined`) → **0 faltando**;
  - multiplicadores conferidos: `Pyrus→Natura` 1.5, `Pyrus→Aquos` 0.5, `Normalis→Draco` 0.5, `Normalis→Pyrus` 1, `Darkus→Haos` 1.5, `Draco→Draco` 1.5.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
