### PR TITLE
fix: agregar materiais do baú em vez de uma linha por sorteio

### DIFF
--- a/src/components/Game/Navbar/ExploreNavbar/Inventory/ChestRewards/index.tsx
+++ b/src/components/Game/Navbar/ExploreNavbar/Inventory/ChestRewards/index.tsx
@@ -67,8 +67,8 @@ export function ChestRewards({
       {result.equipment.length > 0 && (
         <div className={styles.section}>
           <h4>Equipamentos</h4>
-          {result.equipment.map((eq) => (
-            <div key={eq.id} className={styles.dropRow}>
+          {result.equipment.map((eq, index) => (
+            <div key={`${eq.id}-${index}`} className={styles.dropRow}>
               <img
                 className="dropIcon"
                 src={asset(FILTER_LABELS[eq.slot])}

--- a/src/data/items/chests.ts
+++ b/src/data/items/chests.ts
@@ -145,6 +145,16 @@ function pickWeighted<K extends string | number>(
   return positive[positive.length - 1]![0];
 }
 
+/**
+ * Sorteia o conteúdo de um baú.
+ *
+ * Materiais são acumulados por id em vez de virar uma entrada por
+ * sorteio. Como o baú faz de 5 a 11 sorteios sobre uma tabela de 2 ou 3
+ * materiais, repetir é o caso normal — em amostragem de 10 mil baús,
+ * 96% a 99% deles repetem pelo menos um id. Uma entrada por sorteio
+ * fazia a tela de recompensa listar o mesmo material várias vezes com
+ * quantidades parciais, e colidia a key do React, que usa o id.
+ */
 export function openChest(
   chestTier: NPCClass,
   petChance?: number,
@@ -152,6 +162,18 @@ export function openChest(
   const table = CHEST_DROP_TABLES[chestTier];
   const dropCount = Math.floor(Math.random() * 7) + 5;
   const result: ChestDropResult = { materials: [], equipment: [], pets: [] };
+  const materialsById = new Map<string, ChestDropResult["materials"][number]>();
+
+  const addMaterial = (id: string, name: string, qty: number) => {
+    const existing = materialsById.get(id);
+    if (existing) {
+      existing.qty += qty;
+      return;
+    }
+    const entry = { id, name, qty };
+    materialsById.set(id, entry);
+    result.materials.push(entry);
+  };
 
   for (let i = 0; i < dropCount; i++) {
     const isMaterial = Math.random() < 0.7;
@@ -160,18 +182,13 @@ export function openChest(
       const matId = pickWeighted(table.materialWeights);
       if (matId) {
         const craftDef = CRAFT_MATERIALS[matId as keyof typeof CRAFT_MATERIALS];
+        const qty = Math.floor(Math.random() * 3) + 1;
         if (craftDef) {
-          const qty = Math.floor(Math.random() * 3) + 1;
-          result.materials.push({ id: craftDef.id, name: craftDef.name, qty });
+          addMaterial(craftDef.id, craftDef.name, qty);
         } else {
           const itemDef = ITEMS[matId as keyof typeof ITEMS];
           if (itemDef) {
-            const qty = Math.floor(Math.random() * 3) + 1;
-            result.materials.push({
-              id: matId,
-              name: itemDef.name,
-              qty,
-            });
+            addMaterial(matId, itemDef.name, qty);
           }
         }
       }


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Bug encontrado durante a validação do PR de mochila cheia (#11), independente dele. Toca arquivos diferentes, sem conflito.
> - Muda o **formato do resultado** de `openChest`, não a quantidade entregue. Totais no inventário ficam idênticos.

## Problema

`openChest` fazia um `push` por sorteio:

```ts
for (let i = 0; i < dropCount; i++) {
  // ...
  result.materials.push({ id: craftDef.id, name: craftDef.name, qty });
}
```

O baú faz de 5 a 11 sorteios sobre uma tabela de **2 ou 3 materiais**. Repetir não é caso de borda, é o caso normal. Amostrando 10 mil baús por tier:

| Tier | Baús com id repetido | Máx. de linhas | Máx. de materiais distintos |
| --- | --- | --- | --- |
| common | **96,2%** | 11 | 3 |
| rare | **96,2%** | 11 | 3 |
| epic | **98,6%** | 11 | 2 |
| boss | **99,0%** | 11 | 2 |
| legendary | **99,0%** | 11 | 2 |

Ou seja: até **11 linhas para 2 materiais diferentes**.

Duas consequências:

**1. Tela de recompensa errada.** O mesmo material aparecia várias vezes com quantidades parciais — "Totem de Figurante x1", depois "x3", depois "x1" — em vez de uma linha com o total.

**2. Key duplicada no React.** `ChestRewards` usa o id como key (`key={m.id}`). Abrir um baú bem sorteado logava **~180 erros** de `Encountered two children with the same key, 'figurant_totem'`. Não é só ruído de console: React explicitamente não garante o resultado com key repetida, podendo omitir ou duplicar linhas.

## Solução

### `data/items/chests.ts` — acumular na origem

Materiais passam a ser acumulados por id, somando `qty`. A entrada é criada uma vez e mutada in-place através de um `Map`, então a **ordem de inserção** — e portanto a ordem de exibição — é preservada.

Corrigir na origem em vez de na view resolve os dois sintomas de uma vez: a lista fica certa e a key volta a ser única. Os consumidores (`useChestOpening`, `useDailyChest`) percorrem o array chamando `addItem` por entrada, que empilha do mesmo jeito, então o total entregue não muda.

### `ChestRewards/index.tsx` — key composta no equipamento

Equipamento **pode** repetir legitimamente, com nível de aprimoramento diferente, então agregar seria errado. A key virou `id` + índice.

Isso é preventivo: em 10 mil baús por tier não apareceu **nenhum** equipamento duplicado (o sorteio escolhe slot e ranque a cada vez, o que espalha bastante). Latente, não observado — mas é uma linha e fecha a mesma classe de defeito.

## Screenshots

**Descrição do Screenshot**: Tela do baú diário depois da mudança, validada no browser com Playwright MCP. A seção "Materiais" mostra uma linha por material com o total somado — "Chifre de Cabra x4" e "Escama Rara x2" — em vez de várias linhas parciais do mesmo item. O console fica limpo, sem nenhum dos ~180 erros de key duplicada.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Nenhum passo especial. Nada persistido muda de formato.

**Validação local executada**:
- `npx tsc -b --force` → só o erro pré-existente de `useSceneLayers.ts` (corrigido em PR separado).
- `npx eslint` nos dois arquivos tocados → limpo.
- **Amostragem de 10.000 baús** no browser, depois da mudança: `0` baús com id duplicado, `0` entradas com `qty` inválida.
- **Fluxo real**: baú diário aberto com a mochila vazia → tela lista "Chifre de Cabra x4" e "Escama Rara x2"; `browser_console_messages` retorna **0 erros** (antes: ~180); mochila gravada com exatamente `goat_horn: 4` e `rare_scale: 2`, confirmando que o total entregue não mudou.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
