### PR TITLE
feat: classes de tamanho de rocha com altura e colisão

### DIFF
--- a/src/data/scene/rocks.ts
+++ b/src/data/scene/rocks.ts
@@ -1,0 +1,35 @@
+export const ROCK_SIZES = ["small", "medium", "large"] as const;
+
+export type RockSize = (typeof ROCK_SIZES)[number];
+
+export type RockClass = {
+  /**
+   * Altura da rocha no mapa. Rocha escalável usa essa altura como a altura do
+   * jogador quando ele sobe nela; rocha não escalável usa só como referência
+   * visual (elevação do sprite).
+   */
+  height: number;
+  /** Escala do sprite em relação ao tile. */
+  scale: number;
+  /**
+   * Se o jogador pode subir na rocha. Só a rocha pequena é escalável: média e
+   * grande viram parede no mapa de colisão, mas continuam interagíveis do chão
+   * (o jogador minera de fora, não de cima).
+   */
+  climbable: boolean;
+};
+
+/**
+ * Classes de rocha do jogo, por tamanho.
+ *
+ * - pequena: altura 1, o jogador sobe nela e passa a ter altura 1 no mapa;
+ * - média: altura 2, parede;
+ * - grande: altura 3, parede.
+ */
+export const ROCK_CLASSES: Record<RockSize, RockClass> = {
+  small: { height: 1, scale: 0.7, climbable: true },
+  medium: { height: 2, scale: 1.2, climbable: false },
+  large: { height: 3, scale: 1.8, climbable: false },
+};
+
+export const ROCK_IMAGE = "/assets/map/rock.svg";

--- a/src/features/jomasioEntrance/index.tsx
+++ b/src/features/jomasioEntrance/index.tsx
@@ -20,7 +20,10 @@ import type {
 import { SceneBase } from "@/components/Game/Scenes/Base";
 import Talking from "@/components/Game/Interactions/Talking";
 
-import { JOMASIO_ENTRANCE_SCENES } from "@/scenes/jomasioEntrance";
+import {
+  JOMASIO_ENTRANCE_SCENES,
+  jomasioEntranceRocks,
+} from "@/scenes/jomasioEntrance";
 import { sceneBackgrounds } from "@/data/scene/background";
 import { ITEMS } from "@/data/items";
 import {
@@ -34,6 +37,7 @@ import {
 import { rollWoodGather } from "@/gameRules/professions/wood";
 import { rollMineGather } from "@/gameRules/professions/mine";
 import { rollProfessionMaterial } from "@/gameRules/professions/weapon";
+import { rockGridKey, toRockTiles } from "@/gameRules/movement/rocks";
 import { THREE_THOUSAND_MS } from "@/data/ms";
 
 type Props = {
@@ -41,6 +45,12 @@ type Props = {
 };
 
 const MINE_COOLDOWN_MS = THREE_THOUSAND_MS;
+
+const ROCK_TILES = toRockTiles(jomasioEntranceRocks);
+
+const ROCK_LABELS = Object.fromEntries(
+  jomasioEntranceRocks.map((rock) => [rockGridKey(rock), "[L] Minerar"]),
+);
 
 type MineRockDeps = ToolDeps & {
   addItem: (item: InventoryItem) => void;
@@ -173,17 +183,25 @@ export function JomasioEntranceScene({ sceneId }: Props) {
         },
       );
 
+    const mineDeps = {
+      setPopup,
+      addItem,
+      hasToolEquipped,
+      character: player.character,
+      getProficiency,
+      addProficiencyXP,
+      equippedWeaponId,
+    };
+
+    const rockInteractions = Object.fromEntries(
+      jomasioEntranceRocks.map((rock) => [
+        rockGridKey(rock),
+        () => mineRock(getLowestOreLevel())(mineDeps),
+      ]),
+    );
+
     return {
-      "13,10": () =>
-        mineRock(getLowestOreLevel())({
-          setPopup,
-          addItem,
-          hasToolEquipped,
-          character: player.character,
-          getProficiency,
-          addProficiencyXP,
-          equippedWeaponId,
-        }),
+      ...rockInteractions,
       "5,7": () =>
         chopWood(WOOD_LEVELS[0]?.treeLevel ?? 0)({
           setPopup,
@@ -216,18 +234,10 @@ export function JomasioEntranceScene({ sceneId }: Props) {
         background={sceneBackgrounds.JomasioEntrance}
         interactions={interactions}
         interactionLabels={{
-          "13,10": "[L] Minerar",
+          ...ROCK_LABELS,
           "5,7": "[L] Lenhar",
         }}
-        itemPickupTiles={[
-          {
-            x: 13,
-            y: 9,
-            visible: true,
-            image: "/assets/map/rock.svg",
-            size: 1.4,
-          },
-        ]}
+        itemPickupTiles={ROCK_TILES}
         popup={popup}
         setPopup={setPopup}
         onFinishExtra={() => ({

--- a/src/gameRules/movement/rocks.ts
+++ b/src/gameRules/movement/rocks.ts
@@ -1,0 +1,85 @@
+import {
+  ROCK_CLASSES,
+  ROCK_IMAGE,
+  type RockSize,
+} from "@/data/scene/rocks";
+import type { ItemPickupTile } from "@/utils/types/maps/exploreScene";
+
+export type SceneRock = {
+  x: number;
+  y: number;
+  size: RockSize;
+};
+
+const WALL_TILE = 1;
+
+/**
+ * Devolve o mapa de colisão com as rochas não escaláveis viradas parede.
+ *
+ * Rocha pequena não entra aqui: ela continua andável para o jogador poder
+ * subir nela, e a altura no heightMap é que impede/permite o passo.
+ */
+export function applyRocksToMap(
+  map: number[][],
+  rocks: SceneRock[],
+): number[][] {
+  const patched = map.map((row) => [...row]);
+
+  for (const rock of rocks) {
+    if (ROCK_CLASSES[rock.size].climbable) continue;
+    const row = patched[rock.y];
+    if (!row || row[rock.x] === undefined) continue;
+    row[rock.x] = WALL_TILE;
+  }
+
+  return patched;
+}
+
+/**
+ * Constrói o heightMap da cena a partir das rochas escaláveis.
+ *
+ * Cada rocha escalável eleva o tile dela para a altura da própria classe, o
+ * que faz `canStepTo` liberar o passo (diferença de 1) e `getTileHeight`
+ * atualizar a altura do jogador quando ele sobe.
+ */
+export function buildRockHeightMap(
+  map: number[][],
+  rocks: SceneRock[],
+): number[][] {
+  const heightMap = map.map((row) => row.map(() => 0));
+
+  for (const rock of rocks) {
+    const rockClass = ROCK_CLASSES[rock.size];
+    if (!rockClass.climbable) continue;
+    const row = heightMap[rock.y];
+    if (!row || row[rock.x] === undefined) continue;
+    row[rock.x] = rockClass.height;
+  }
+
+  return heightMap;
+}
+
+/**
+ * Converte as rochas da cena nos tiles de sprite que a ExploreScene desenha.
+ *
+ * A escala e a elevação do sprite saem da classe da rocha, então o tamanho
+ * visual acompanha o tamanho de gameplay sem duplicar número na cena.
+ */
+export function toRockTiles(rocks: SceneRock[]): ItemPickupTile[] {
+  return rocks.map((rock) => {
+    const rockClass = ROCK_CLASSES[rock.size];
+    return {
+      x: rock.x,
+      y: rock.y,
+      visible: true,
+      image: ROCK_IMAGE,
+      size: rockClass.scale,
+      height: rockClass.height,
+    };
+  });
+}
+
+/** Chave de grid (`"x,y"`) usada pelo mapa de interações da cena. */
+export function rockGridKey(rock: SceneRock): string {
+  return `${rock.x},${rock.y}`;
+}

--- a/src/scenes/jomasioEntrance/index.ts
+++ b/src/scenes/jomasioEntrance/index.ts
@@ -1,5 +1,7 @@
 import { oneScene } from "./one/scene";
 
+export { jomasioEntranceRocks } from "./one/rocks";
+
 export const JOMASIO_ENTRANCE_SCENES: Partial<Record<SceneId, SceneConfig>> = {
   one: oneScene,
 };

--- a/src/scenes/jomasioEntrance/one/rocks.ts
+++ b/src/scenes/jomasioEntrance/one/rocks.ts
@@ -1,0 +1,14 @@
+import type { SceneRock } from "@/gameRules/movement/rocks";
+
+/**
+ * Rochas da entrada de Jomasio.
+ *
+ * A rocha grande em (13,10) é a parede que o jogador minera de fora; a
+ * pequena em (10,10) é escalável (leva o jogador para a altura 1) e a média
+ * em (16,10) bloqueia a passagem sem poder ser escalada.
+ */
+export const jomasioEntranceRocks: SceneRock[] = [
+  { x: 13, y: 10, size: "large" },
+  { x: 10, y: 10, size: "small" },
+  { x: 16, y: 10, size: "medium" },
+];

--- a/src/scenes/jomasioEntrance/one/scene.ts
+++ b/src/scenes/jomasioEntrance/one/scene.ts
@@ -1,12 +1,18 @@
 import { jomasioEntrance } from "@/maps/jomasioEntrance";
 import { MUSICS } from "@/scenes/shared/music";
+import {
+  applyRocksToMap,
+  buildRockHeightMap,
+} from "@/gameRules/movement/rocks";
 import { getJomasioEntranceInitialPosition } from "./position";
 import { jomasioEntranceTiles } from "./tiles";
 import { jomasioEntrancePlates } from "./plate";
+import { jomasioEntranceRocks } from "./rocks";
 
 export const oneScene: SceneConfig = {
   id: "one",
-  map: jomasioEntrance,
+  map: applyRocksToMap(jomasioEntrance, jomasioEntranceRocks),
+  heightMap: buildRockHeightMap(jomasioEntrance, jomasioEntranceRocks),
   scaleFix: 1.4,
   audio: { src: MUSICS.default },
   initialPosition: getJomasioEntranceInitialPosition,


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Sem migration, sem env var, sem script. A mudança é de dados de cena + regra pura de movimento.
> - `origin/main` já chega com `npm run type-check` quebrado (5 erros em `src/data/professions/gathering.ts`, ids de madeira que não existem mais em `ITEMS`). Esta branch não adiciona nenhum erro novo; a correção vai na branch de profissões.
> - A rocha média em (16,10) e a pequena em (10,10) são novas na entrada de Jomasio — entraram para as três classes existirem no jogo e a escalada ser testável.

## Problema

A rocha da entrada de Jomasio era só um sprite: o tile dela seguia andável no `map`, então o jogador atravessava a rocha (#89). E não havia noção de tamanho de rocha — o sprite tinha `size: 1.4` cravado na cena, o número não tinha relação com nenhuma regra e não existia rocha escalável (#140).

Além disso o sprite estava em `(13,9)` enquanto a interação de minerar estava em `(13,10)`: o desenho e o tile de gameplay eram dois números soltos, mantidos em sincronia à mão.

## Solução

### `src/data/scene/rocks.ts`

Classes de rocha por tamanho, com altura, escala do sprite e se é escalável:

| Tamanho | Altura | Escala | Escalável |
| --- | --- | --- | --- |
| pequena | 1 | 0.7 | sim |
| média | 2 | 1.2 | não |
| grande | 3 | 1.8 | não |

### `src/gameRules/movement/rocks.ts`

Regras puras que derivam a cena da lista de rochas:

- `applyRocksToMap` — rocha não escalável vira parede (`1`) no mapa de colisão. É isso que impede o jogador de andar por cima e o que resolve #89, mantendo a rocha interagível: `getTileInFront`/`isPositionInFront` não olham o valor do tile, então o `[L] Minerar` continua aparecendo do chão.
- `buildRockHeightMap` — rocha escalável eleva o tile para a altura da classe. `canStepTo` (`MAX_STEP_UP = 1`) libera o passo e `getTileHeight` passa o jogador para a altura 1 quando ele sobe.
- `toRockTiles` — converte a rocha no tile de sprite da `ExploreScene`, tirando escala e elevação da própria classe. Tamanho visual e tamanho de gameplay deixam de ser dois números independentes.

### Entrada de Jomasio

`src/scenes/jomasioEntrance/one/rocks.ts` declara as rochas da cena; `scene.ts` monta `map` e `heightMap` a partir delas; a feature gera interação, label e sprite iterando a mesma lista, em vez de repetir `"13,10"` em três lugares.

A rocha existente virou **grande** (parede, altura 3, sprite maior — era `1.4`, agora `1.8`).

## Screenshots

**Descrição do Screenshot**:

1. Entrada de Jomasio com as três rochas: pequena (10,10), grande (13,10) e média (16,10), cada uma com tamanho visual distinto.
2. Jogador sobre a rocha pequena — sprite elevado, altura 1 no mapa.
3. Jogador parado ao lado da rocha grande com o hint `[L] Minerar` visível: três `ArrowRight` seguidos não o fazem atravessar a rocha.
4. `L` com a picareta não equipada devolve `Você precisa equipar uma picareta para minerar.` — a interação dispara normalmente mesmo com o tile virado parede.

## Outras mudanças

- `src/scenes/jomasioEntrance/index.ts` passa a re-exportar `jomasioEntranceRocks`, para a feature importar do nível de módulo (`@/scenes/jomasioEntrance`) como manda o AGENTS.md.

## Notas sobre deploy

Nada a fazer no deploy: build normal.

**Validação local executada**:
- `npx eslint src/data/scene/rocks.ts src/gameRules/movement/rocks.ts src/scenes/jomasioEntrance src/features/jomasioEntrance` — limpo.
- `npm run type-check` — 5 erros, todos pré-existentes em `src/data/professions/gathering.ts` (idênticos em `origin/main`); zero erro nos arquivos desta branch.
- Playwright MCP em `http://localhost:5191/react-jomasio-adventures/jomasioentrance/one` (Chromium, 1265x917 e 414x896): subiu na rocha pequena, foi bloqueado pela grande, `[L] Minerar` apareceu e disparou. `browser_console_messages` com 0 erro.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma

---

## Validação completa (rodada dedicada)

**Estático**
- `npm run type-check`: 5 erros, todos em `src/data/professions/gathering.ts` — idênticos ao baseline de `origin/main` medido em worktree separada. Zero nos arquivos desta branch.
- `npx eslint .` (projeto inteiro): limpo.
- `npx vite build` + `npm run build:sw`: exit 0 nos dois. (`npm run build` completo não passa por causa do `tsc -b` herdado da `main`; o conserto está no PR de profissões.)

**Browser (Playwright MCP, 1400x900, código já commitado)**

Medições no DOM, não impressão de tela:

| Rocha | Largura renderizada | Escala esperada (TILE 69px) | Elevação do sprite (`top`) |
| --- | --- | --- | --- |
| pequena (10,10) | 48px | 0.7 × 69 = 48 ✓ | 725.2 |
| média (16,10) | 83px | 1.2 × 69 = 83 ✓ | 690.7 |
| grande (13,10) | 124px | 1.8 × 69 = 124 ✓ | 656.1 |

As elevações caem em degraus de exatamente **34.5px** (= `HEIGHT_STEP_OFFSET` 0.5 × 69), na ordem altura 1 → 2 → 3. Tamanho visual e altura de gameplay saem da mesma classe.

**Colisão (#89)** — encostado na rocha grande, 6 `ArrowRight` seguidos: `top` do jogador inalterado **e** as três rochas nas mesmas coordenadas de tela (541 / 748 / 956). Como a câmera acompanha o jogador, cenário parado prova que ele não andou um tile. O hint `[L] Minerar` segue visível durante o bloqueio.

**Escalada (#140)** — 2 `ArrowLeft` até a rocha pequena: `top` do jogador **604 → 570** (−34px = meio tile = altura 1). Um passo a mais para o chão: **570 → 604**. As rochas deslocam 69px por tile, confirmando que o movimento aconteceu de verdade.

`browser_console_messages`: 0 erro.
