### PR TITLE
feat: gradiente do quadro do personagem pela tipagem

### DIFF
--- a/src/components/Game/Battle/HUD/PlayerPanel/index.tsx
+++ b/src/components/Game/Battle/HUD/PlayerPanel/index.tsx
@@ -6,8 +6,11 @@ import { playerPath } from "@/utils/paths";
 import type { ElementType } from "@/utils/types/battle/element";
 import styles from "../styles.module.css";
 import { asset } from "@/utils/paths";
+// import { characterFaceStyle } from "@/utils/character/elementFace";
+// import type { CharacterOption } from "@/utils/types/player/character";
 
 type Props = {
+  // characterColor: CharacterOption & { unlockedDate?: string | null };
   character: string;
   playerName: string;
   playerRank: string;
@@ -22,6 +25,7 @@ type Props = {
 };
 
 export function PlayerHUDPanel({
+  // characterColor,
   character,
   playerName,
   playerRank,
@@ -36,11 +40,13 @@ export function PlayerHUDPanel({
 }: Props) {
   return (
     <div className={styles.container} style={{ left: 10, top: 10 }}>
-      <div>
+      <div
+        >
         <img
           src={playerPath(`/${character}/face.svg`)}
           alt="Player HUD"
           className="hudImage"
+          // style={characterFaceStyle(characterColor.image)}
         />
         <img
           src={asset(`/assets/badges/ranks/${playerRank}`)}

--- a/src/components/Game/Battle/HUD/index.tsx
+++ b/src/components/Game/Battle/HUD/index.tsx
@@ -4,6 +4,7 @@ import type { SummonedNpc } from "@/utils/types/npc/npc";
 import { getRank, srcRank } from "@/gameRules/rank";
 import { CHARACTER_ELEMENT_TYPES } from "@/data/types/characterElementTypes";
 import { getNpcElementTypes } from "@/data/types/npcElementTypes";
+// import { CHARACTERS } from "@/data/options/characters";
 import { PlayerHUDPanel } from "./PlayerPanel";
 import { NPCHUDPanel } from "./NpcPanel";
 import { SummonHUDList } from "./SummonList";
@@ -45,11 +46,13 @@ export function BattleHUD({
   const { progress } = useCharacterProgress();
   const playerName = localStorage.getItem("playerName") || "Protagonista";
 
+  // const characterColor = CHARACTERS.find((c) => c.image === player.character);
   const playerRank = `${srcRank(getRank(progress[player.character]?.level ?? 1))}`;
 
   return (
     <>
       <PlayerHUDPanel
+        // characterColor={characterColor!}
         character={player.character}
         playerName={playerName}
         playerRank={playerRank}

--- a/src/components/Game/Navbar/shared/CharacterCard/index.tsx
+++ b/src/components/Game/Navbar/shared/CharacterCard/index.tsx
@@ -4,6 +4,7 @@ import { playerPath, asset } from "@/utils/paths";
 import { getRank, formatRank, srcRank } from "@/gameRules/rank";
 import { CHARACTER_ELEMENT_TYPES } from "@/data/types/characterElementTypes";
 import { getXPToNextLevel } from "@/utils/character/progress";
+import { characterFaceStyle } from "@/utils/character/elementFace";
 import type { CharacterOption } from "@/utils/types/player/character";
 
 type CharacterProgress = {
@@ -38,11 +39,16 @@ export function CharacterCard({
     >
       {isSelected && <span className={`cursor ${styles.cursor}`}>▼</span>}
 
-      <img
-        src={playerPath(`/${character.image}/default.svg`)}
-        className={styles.characterImage}
-        alt={character.name}
-      />
+      <div
+        className={styles.imageFrame}
+        style={characterFaceStyle(character.image)}
+      >
+        <img
+          src={playerPath(`/${character.image}/default.svg`)}
+          className={styles.characterImage}
+          alt={character.name}
+        />
+      </div>
       <div className={styles.flexColumn}>
         <h2 className={styles.text}>
           <span className={styles.levelRow}>

--- a/src/components/Game/Navbar/shared/CharacterCard/index.tsx
+++ b/src/components/Game/Navbar/shared/CharacterCard/index.tsx
@@ -4,7 +4,6 @@ import { playerPath, asset } from "@/utils/paths";
 import { getRank, formatRank, srcRank } from "@/gameRules/rank";
 import { CHARACTER_ELEMENT_TYPES } from "@/data/types/characterElementTypes";
 import { getXPToNextLevel } from "@/utils/character/progress";
-import { characterFaceStyle } from "@/utils/character/elementFace";
 import type { CharacterOption } from "@/utils/types/player/character";
 
 type CharacterProgress = {
@@ -39,16 +38,11 @@ export function CharacterCard({
     >
       {isSelected && <span className={`cursor ${styles.cursor}`}>▼</span>}
 
-      <div
-        className={styles.imageFrame}
-        style={characterFaceStyle(character.image)}
-      >
-        <img
-          src={playerPath(`/${character.image}/default.svg`)}
-          className={styles.characterImage}
-          alt={character.name}
-        />
-      </div>
+      <img
+        src={playerPath(`/${character.image}/default.svg`)}
+        className={styles.characterImage}
+        alt={character.name}
+      />
       <div className={styles.flexColumn}>
         <h2 className={styles.text}>
           <span className={styles.levelRow}>

--- a/src/components/Game/Navbar/shared/CharacterCard/styles.module.css
+++ b/src/components/Game/Navbar/shared/CharacterCard/styles.module.css
@@ -24,18 +24,6 @@
   margin-top: var(--fs-10);
 }
 
-.imageFrame {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 30%;
-  aspect-ratio: 1 / 1;
-  border: var(--size-2) solid var(--primary-color);
-  border-radius: var(--fs-16);
-  overflow: hidden;
-}
-
 .characterImage {
   height: 90%;
   width: auto;

--- a/src/components/Game/Navbar/shared/CharacterCard/styles.module.css
+++ b/src/components/Game/Navbar/shared/CharacterCard/styles.module.css
@@ -24,9 +24,22 @@
   margin-top: var(--fs-10);
 }
 
-.characterImage {
-  height: 80%;
+.imageFrame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
   width: 30%;
+  aspect-ratio: 1 / 1;
+  border: var(--size-2) solid var(--primary-color);
+  border-radius: var(--fs-16);
+  overflow: hidden;
+}
+
+.characterImage {
+  height: 90%;
+  width: auto;
+  object-fit: contain;
 }
 
 .characterDisabled {

--- a/src/utils/character/elementFace.ts
+++ b/src/utils/character/elementFace.ts
@@ -1,0 +1,19 @@
+import type { CSSProperties } from "react";
+import { getCharacterElementGradient } from "@/data/types/elementGradients";
+
+const GRADIENT_ANGLE = "150deg";
+
+/**
+ * Estilo do quadro onde a face do personagem fica, derivado da tipagem dele.
+ *
+ * Uma tipagem rende o gradiente da própria cor (Aquos = tons de azul); duas
+ * ou mais rendem a mistura, na ordem em que a tipagem foi declarada em
+ * CHARACTER_ELEMENT_TYPES (Aquos + Pyrus = azul virando vermelho).
+ * Personagem sem tipagem declarada cai no gradiente neutro.
+ */
+export function characterFaceStyle(character: string): CSSProperties {
+  const colors = getCharacterElementGradient(character);
+  return {
+    background: `linear-gradient(${GRADIENT_ANGLE}, ${colors.join(", ")})`,
+  };
+}


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Mudança visual: o quadro do personagem virou um quadrado (`aspect-ratio: 1 / 1`) com fundo em gradiente. O sprite deixou de ser esticado (`height: 80%; width: 30%`) e passa a caber no quadro por `object-fit: contain`.
> - `ELEMENT_GRADIENTS` e `getCharacterElementGradient` já existiam em `src/data/types/elementGradients.ts` e **não tinham nenhum uso** no projeto. Este PR passa a consumi-los em vez de criar uma segunda tabela de cor por elemento.
> - `origin/main` já chega com `npm run type-check` quebrado (5 erros em `src/data/professions/gathering.ts`). Esta branch não adiciona erro novo.

## Problema

O quadro onde a face do personagem aparece era neutro: mesma borda `--primary-color` para todo mundo, sem nenhuma relação com a tipagem. A tipagem só aparecia nos badges minúsculos ao lado do nome, então bater o olho no card não dizia nada sobre o elemento do personagem.

A tabela de cor por elemento para isso já estava escrita (`ELEMENT_GRADIENTS`, com 3 tons por elemento) e nunca tinha sido ligada em nada — código morto esperando um consumidor.

## Solução

### `src/utils/character/elementFace.ts`

`characterFaceStyle(character)` devolve `CSSProperties` com o `linear-gradient(150deg, …)` montado a partir de `getCharacterElementGradient`, seguindo o mesmo formato de `petStarStyle` em `utils/character/petVisuals.ts`.

Comportamento por tipagem:

- **uma tipagem** → gradiente da própria cor (Aquos = tons de azul);
- **duas ou mais** → mistura, na ordem em que a tipagem está declarada em `CHARACTER_ELEMENT_TYPES` (Aquos + Pyrus = azul virando vermelho);
- **sem tipagem declarada** → gradiente neutro (`DEFAULT_GRADIENT`), sem quebrar.

### `CharacterCard`

O sprite passou a morar dentro de um `.imageFrame` quadrado que recebe o gradiente. Como a `ExploreNavbar/Character` e a `BattleNavbar/Characters` já consomem o `CharacterCard` compartilhado, as duas telas mudam com uma alteração só.

## Screenshots

**Descrição do Screenshot**:

1. Aba **Personagem** (1400x900): Marshadow com quadro azul→ciano→verde (Aquos + Natura) e Drika com branco→dourado, cada um casando com os badges de tipagem ao lado do nome.
2. Mesma tela em mobile landscape (896x414): quadros seguem quadrados e legíveis.
3. Leitura via DOM dos 12 cards confirmando um gradiente distinto por tipagem e `157x157` (quadrado) em todos — inclusive riquelme (Aquos + Umbra) azul→roxo escuro e levi (3 tipagens) com a paleta das três.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Nada a fazer no deploy: build normal.

**Validação local executada**:
- `npx eslint src/utils/character/elementFace.ts src/components/Game/Navbar/shared/CharacterCard` — limpo.
- `npm run type-check` — só os 5 erros pré-existentes de `gathering.ts`; zero nos arquivos desta branch.
- Playwright MCP em `http://localhost:5192/react-jomasio-adventures/jomasioentrance/one` → navbar (`g`) → aba Personagem, nos viewports 1400x900, 896x414 e 414x896. `browser_console_messages` com 0 erro.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma

---

## Validação completa (rodada dedicada)

**Estático**
- `npm run type-check`: 5 erros, todos herdados de `gathering.ts` na `main` (baseline conferido em worktree separada). Zero nos arquivos desta branch.
- `npx eslint .` (projeto inteiro): limpo.
- `npx vite build` + `npm run build:sw`: exit 0 nos dois.

**Browser (Playwright MCP, código já commitado)**

Leitura de `getComputedStyle` nos 12 cards, com todos os personagens desbloqueados por flag:

- **12/12 quadrados** — 157×157 em 1400x900, e seguem quadrados em mobile landscape 896x414 (115×115 e 124×124, conforme a coluna do grid);
- **12/12** com `linear-gradient(150deg, …)` e **6 paradas de cor** (3 tons por tipagem × 2 tipagens); nenhum card ficou sem gradiente;
- **11 gradientes distintos entre 12 cards**: `artur` e `mayra` compartilham o mesmo porque têm a **mesma tipagem** (`["Darkus","Umbra"]`). É consequência esperada de derivar a cor da tipagem, não defeito — se quiser diferenciá-los, o caminho é mudar a tipagem de um dos dois (ou embutir a ordem do personagem no gradiente);
- sem overflow horizontal na página em 896x414.

`browser_console_messages`: 0 erro.
