### PR TITLE
feat: babidi block com reflexo e teleport do giro do maurão

### DIFF
--- a/src/components/Game/Battle/Effects/DamageNumbers/index.tsx
+++ b/src/components/Game/Battle/Effects/DamageNumbers/index.tsx
@@ -21,6 +21,7 @@ const TYPE_CLASS: Record<string, string> = {
   summon: styles.summon!,
   blocked: styles.blocked!,
   parry: styles.parry!,
+  reflect: styles.reflect!,
   crit: styles.crit!,
   charge: styles.charge!,
   miss: styles.miss!,

--- a/src/components/Game/Battle/Effects/DamageNumbers/styles.module.css
+++ b/src/components/Game/Battle/Effects/DamageNumbers/styles.module.css
@@ -120,6 +120,15 @@
   animation: floatBlocked 0.8s ease-out forwards;
 }
 
+.reflect {
+  color: #7c4dff;
+  text-shadow:
+    0 0 var(--size-6) rgba(124, 77, 255, 0.8),
+    var(--size-1) var(--size-1) 0 rgba(0, 0, 0, 0.8),
+    calc(-1 * var(--size-1)) calc(-1 * var(--size-1)) 0 rgba(0, 0, 0, 0.8);
+  animation: floatCrit 1s ease-out forwards;
+}
+
 .armor {
   color: #00e5ff;
   font-size: var(--fs-20);

--- a/src/gameRules/battle/babidiBlock.ts
+++ b/src/gameRules/battle/babidiBlock.ts
@@ -1,0 +1,61 @@
+/** Personagem do jogador que carrega o Babidi Block. */
+export const BABIDI_CHARACTER = "lucaua";
+
+/** Fração do dano bloqueado que volta para o inimigo. */
+export const BABIDI_BLOCK_REFLECT_PERCENT = 5;
+
+/** Ganho no multiplicador de reflexo por nível de vantagem sobre o inimigo. */
+export const BABIDI_REFLECT_BONUS_PER_LEVEL = 0.1;
+
+/** Diferença de nível acima da qual o bloqueio mata o inimigo na hora. */
+export const BABIDI_INSTAKILL_LEVEL_GAP = 20;
+
+export type BabidiBlockReflect = {
+  damage: number;
+  isInstakill: boolean;
+};
+
+type BabidiBlockParams = {
+  character: CharacterId;
+  playerLevel: number;
+  npcLevel: number;
+  blockedDamage: number;
+  npcHp: number;
+};
+
+/**
+ * Dano que volta para o inimigo quando Babidi bloqueia um ataque.
+ *
+ * São 5% do dano que ele sofreria, multiplicado pela vantagem de nível dele
+ * sobre o inimigo (+10% por nível). Passando de 20 níveis de vantagem o
+ * bloqueio mata: o reflexo vale a vida restante do inimigo, para o número de
+ * dano na tela ser o golpe que de fato o derrubou.
+ *
+ * Devolve null quando não é o Babidi, quando não houve dano bloqueado ou
+ * quando o reflexo arredonda para zero — nesses casos nada é aplicado.
+ */
+export function getBabidiBlockReflect({
+  character,
+  playerLevel,
+  npcLevel,
+  blockedDamage,
+  npcHp,
+}: BabidiBlockParams): BabidiBlockReflect | null {
+  if (character !== BABIDI_CHARACTER) return null;
+  if (blockedDamage <= 0) return null;
+
+  const levelGap = playerLevel - npcLevel;
+
+  if (levelGap > BABIDI_INSTAKILL_LEVEL_GAP) {
+    return { damage: Math.max(0, npcHp), isInstakill: true };
+  }
+
+  const multiplier = 1 + Math.max(0, levelGap) * BABIDI_REFLECT_BONUS_PER_LEVEL;
+  const damage = Math.round(
+    ((blockedDamage * BABIDI_BLOCK_REFLECT_PERCENT) / 100) * multiplier,
+  );
+
+  if (damage <= 0) return null;
+
+  return { damage, isInstakill: false };
+}

--- a/src/gameRules/npc/movement.ts
+++ b/src/gameRules/npc/movement.ts
@@ -1,4 +1,5 @@
 import { getChaseMovement } from "@/gameRules/movement/npc";
+import { BATTLE_LIMITS } from "@/gameRules/movement/constants";
 import type { NPCBattleState } from "@/utils/types/npc/npc";
 
 export function chasePlayer(
@@ -8,5 +9,29 @@ export function chasePlayer(
   speedMultiplier: number = 1,
   stopDistance: number = 10,
 ) {
-  return getChaseMovement(npc.x, npc.y, playerX, playerY, speedMultiplier, stopDistance);
+  return getChaseMovement(
+    npc.x,
+    npc.y,
+    playerX,
+    playerY,
+    speedMultiplier,
+    stopDistance,
+  );
+}
+
+/**
+ * X para onde um NPC deve teleportar para aparecer atrás do jogador.
+ *
+ * "Atrás" é o lado oposto ao que o jogador está virado, recuado `offset` px,
+ * sempre dentro dos limites da arena — teleportar para fora deles deixaria o
+ * NPC inalcançável.
+ */
+export function getBehindPlayerX(
+  playerX: number,
+  playerDirection: Direction,
+  offset: number,
+): number {
+  const behindX =
+    playerDirection === "right" ? playerX - offset : playerX + offset;
+  return Math.max(BATTLE_LIMITS.minX, Math.min(BATTLE_LIMITS.maxX, behindX));
 }

--- a/src/hooks/battle/npc/useBlocking.ts
+++ b/src/hooks/battle/npc/useBlocking.ts
@@ -64,6 +64,7 @@ type HandleBlockingParams = {
   onFullBlock?: () => void;
   onBlockRef?: React.RefObject<() => void>;
   onParry?: () => void;
+  onDamageBlocked?: (blockedDamage: number) => void;
 };
 
 export function handleNpcBlocking({
@@ -83,6 +84,7 @@ export function handleNpcBlocking({
   onFullBlock,
   onBlockRef,
   onParry,
+  onDamageBlocked,
 }: HandleBlockingParams): boolean {
   const now = Date.now();
   const pressTime = lastBlockPressRef.current;
@@ -109,6 +111,7 @@ export function handleNpcBlocking({
         spawnDamageRef.current?.(0, playerX, playerY - 40, "blocked");
         npcCooldown.current = false;
         onFullBlock?.();
+        onDamageBlocked?.(dmg);
         onBlockRef?.current?.();
         setTimeout(() => (npcCooldown.current = true), NPC_BLOCK_COOLDOWN);
         return true;

--- a/src/hooks/battle/npc/useNpc.ts
+++ b/src/hooks/battle/npc/useNpc.ts
@@ -9,11 +9,13 @@ import { logPlay } from "@/utils/replay/audioEventLog";
 import { getNpcElementTypes } from "@/data/types/npcElementTypes";
 import { CHARACTER_ELEMENT_TYPES } from "@/data/types/characterElementTypes";
 import { combatService } from "@/services/combat";
+import { getBabidiBlockReflect } from "@/gameRules/battle/babidiBlock";
 
 type Props = {
   npcLevel: number;
   npcClass: NPCClass;
   playerClass: PlayerClass;
+  playerLevel: number;
 
   playerX: number;
   playerY: number;
@@ -58,6 +60,7 @@ export function useNpcBattle({
   npcLevel,
   npcClass,
   playerClass,
+  playerLevel,
   totalArmor,
   damagePlayerHp,
   setPlayer,
@@ -114,6 +117,34 @@ export function useNpcBattle({
     [damagePlayerHp, totalReflect, setNpcHP, spawnDamageRef, npcX, npcY],
   );
 
+  const applyBabidiBlockReflect = useCallback(
+    (blockedDamage: number) => {
+      const reflect = getBabidiBlockReflect({
+        character: player.character,
+        playerLevel,
+        npcLevel,
+        blockedDamage,
+        npcHp: npcHpRef.current,
+      });
+      if (!reflect) return;
+
+      setNpcHP((hp) =>
+        reflect.isInstakill ? 0 : Math.max(0, hp - reflect.damage),
+      );
+      spawnDamageRef.current?.(reflect.damage, npcX, npcY, "reflect");
+    },
+    [
+      player.character,
+      playerLevel,
+      npcLevel,
+      npcHpRef,
+      setNpcHP,
+      spawnDamageRef,
+      npcX,
+      npcY,
+    ],
+  );
+
   const onFullBlock = useCallback(() => {
     if (player.character === "marcelo") {
       playSound("swordDeflected");
@@ -143,6 +174,7 @@ export function useNpcBattle({
         onFullBlock,
         onBlockRef,
         onParry,
+        onDamageBlocked: applyBabidiBlockReflect,
       });
       if (blocked) return;
 
@@ -169,6 +201,7 @@ export function useNpcBattle({
       onFullBlock,
       onBlockRef,
       onParry,
+      applyBabidiBlockReflect,
     ],
   );
 
@@ -594,6 +627,7 @@ function checkBlocked(params: {
   onFullBlock?: () => void;
   onBlockRef?: React.RefObject<() => void>;
   onParry?: () => void;
+  onDamageBlocked?: (blockedDamage: number) => void;
 }): boolean {
   const {
     dmg,
@@ -615,6 +649,7 @@ function checkBlocked(params: {
     onFullBlock,
     onBlockRef,
     onParry,
+    onDamageBlocked,
   } = params;
 
   const isBlocking =
@@ -638,6 +673,7 @@ function checkBlocked(params: {
     onFullBlock,
     onBlockRef,
     onParry,
+    onDamageBlocked,
   });
   return blocked;
 }

--- a/src/hooks/battle/useSystem.ts
+++ b/src/hooks/battle/useSystem.ts
@@ -294,6 +294,7 @@ export function useBattleSystem(props: Props) {
     npcLevel,
     npcClass,
     playerClass,
+    playerLevel: char.level,
     playerX,
     playerY,
     npcX,

--- a/src/services/npc/attacks/maurao/phase2.ts
+++ b/src/services/npc/attacks/maurao/phase2.ts
@@ -1,4 +1,4 @@
-import { chasePlayer } from "@/gameRules/npc/movement";
+import { chasePlayer, getBehindPlayerX } from "@/gameRules/npc/movement";
 import { isNear } from "@/gameRules/npc/behavior";
 
 import type { NPCBattleState } from "@/utils/types/npc/npc";
@@ -17,14 +17,22 @@ import {
   SPIN_MOVE_SPEED,
   SPIN_CYCLE_START_THRESHOLD,
   SPIN_CYCLE_END_THRESHOLD,
+  SPIN_TELEPORT_OFFSET,
 } from "./state";
 
+/**
+ * Fase 2 do Maurão: ciclo de giro (girando -> descansando -> ocioso).
+ *
+ * Ao sair de ocioso para girar ele teleporta para trás do jogador, então o
+ * giro nunca começa longe: fugir do alcance deixa de ser saída, e a resposta
+ * passa a ser o bloqueio ou o dash na janela do primeiro hit do giro.
+ */
 export function mauraoPhase2(
   ctx: BehaviorContext,
   ai: MauraoAI,
 ): BehaviorResult {
   const now = Date.now();
-  const { npc, playerX, playerY, targetX, onMeleeHit } = ctx;
+  const { npc, playerX, playerY, playerDirection, targetX, onMeleeHit } = ctx;
 
   if (ai.spinState === "spinning") {
     const elapsed = now - ai.spinStart;
@@ -36,7 +44,10 @@ export function mauraoPhase2(
     }
 
     const dx = targetX - npc.x;
-    const step = Math.hypot(dx, 0) <= SPIN_MELEE_RANGE ? 0 : Math.min(Math.abs(dx), SPIN_MOVE_SPEED);
+    const step =
+      Math.hypot(dx, 0) <= SPIN_MELEE_RANGE
+        ? 0
+        : Math.min(Math.abs(dx), SPIN_MOVE_SPEED);
     const newX = npc.x + Math.sign(dx) * step;
 
     if (now - ai.lastSpinHit >= SPIN_HIT_INTERVAL) {
@@ -69,7 +80,6 @@ export function mauraoPhase2(
     return { x: npc.x, y: npc.y, state: "idle" as const };
   }
 
-  // idle — check if ready to start spinning
   const canStartSpin =
     ai.spinStart === 0 ||
     (ai.spinRestStart !== 0 && now - ai.spinRestStart >= SPIN_REST_DURATION);
@@ -79,7 +89,11 @@ export function mauraoPhase2(
     ai.spinStart = now;
     ai.lastSpinHit = now;
     ai.spinHitCount = 0;
-    return { x: npc.x, y: npc.y, state: "startSpin" as const };
+    return {
+      x: getBehindPlayerX(playerX, playerDirection, SPIN_TELEPORT_OFFSET),
+      y: npc.y,
+      state: "startSpin" as const,
+    };
   }
 
   const { x } = chasePlayer(npc, targetX, playerY, 1, SPIN_MELEE_RANGE);

--- a/src/services/npc/attacks/maurao/state.ts
+++ b/src/services/npc/attacks/maurao/state.ts
@@ -50,6 +50,14 @@ export const SPIN_MOVE_SPEED = 2;
 export const SPIN_CYCLE_START_THRESHOLD = THREE_HUNDRED_THIRTY_THREE_MS;
 export const SPIN_CYCLE_END_THRESHOLD = THREE_HUNDRED_THIRTY_THREE_MS;
 
+/**
+ * Distância (px) atrás do jogador onde Maurão reaparece ao começar a girar.
+ *
+ * Fica além de SPIN_MELEE_RANGE para o teleport não acertar de graça: o
+ * jogador ainda tem a janela do primeiro SPIN_HIT_INTERVAL para reagir.
+ */
+export const SPIN_TELEPORT_OFFSET = 70;
+
 export function initMauraoAi(npcPhase: number): MauraoAI {
   return {
     knownPhase: npcPhase,


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - `useNpcBattle` ganhou a prop obrigatória `playerLevel` (passada de `useSystem` como `char.level`). Quem chamar o hook fora de `useSystem` precisa passar também — hoje só existe esse call site.
> - Decisões de balanceamento que a issue não fixa: **+10% de multiplicador por nível de vantagem** e o reflexo **só no bloqueio total** (não no guard break, no bloqueio desesperado nem no parry). Ambas ficam em constantes nomeadas, fáceis de mexer.
> - O teleport do Maurão usa `SPIN_TELEPORT_OFFSET = 70`, propositalmente maior que `SPIN_MELEE_RANGE = 50`: o teleport não acerta de graça, o jogador ainda tem a janela do primeiro `SPIN_HIT_INTERVAL` para reagir.
> - **Defeito pré-existente encontrado** (não corrigido aqui): a batalha loga `Cannot update a component (TitleProvider) while rendering a different component (BattleScene)` uns segundos depois de a luta começar. Reproduzido em worktree que **não** toca código de batalha, ou seja, já está na `main`. Vale issue própria.
> - `origin/main` já chega com `npm run type-check` quebrado (5 erros em `src/data/professions/gathering.ts`). Esta branch não adiciona erro novo.

## Problema

**#111** — o Babidi não tinha nada de próprio no bloqueio: bloquear com ele era igual a bloquear com qualquer outro personagem. O reflexo que existia (`damagePlayerWithReflect`) só cobre dano **que passa**, vindo de equipamento, então dano absorvido pela barra de bloqueio não devolvia nada.

**#153** — na fase 2 o Maurão começava a girar de onde estivesse. Como o giro persegue no eixo X a `SPIN_MOVE_SPEED = 2`, quem estivesse longe simplesmente andava para o lado oposto e assistia aos 8s de giro passarem sem risco. A mecânica mais marcante da fase era evitável andando.

## Solução

### Babidi Block (`src/gameRules/battle/babidiBlock.ts`)

`getBabidiBlockReflect` é pura e responde uma coisa: quanto volta para o inimigo quando o Babidi bloqueia.

| Situação | Resultado |
| --- | --- |
| personagem ≠ `lucaua` | `null` (nada acontece) |
| dano bloqueado 0 | `null` |
| mesmo nível | 5% do dano bloqueado |
| +10 níveis de vantagem | 5% × 2.0 |
| +20 níveis de vantagem | 5% × 3.0 |
| mais de 20 níveis | mata o inimigo; o dano exibido é a vida restante dele |
| desvantagem de nível | piso de 5% (nunca menos) |

O gancho no fluxo é um callback novo `onDamageBlocked?: (blockedDamage: number) => void` em `handleNpcBlocking`, chamado **no ramo de bloqueio total** (`dmg <= blockGauge`) junto de `onFullBlock`. `useNpc` implementa o callback: aplica o dano no NPC e cospe o número com o `DamageType` `"reflect"` que já existia.

### Teleport do giro (`src/services/npc/attacks/maurao/`)

`getBehindPlayerX(playerX, playerDirection, offset)` entrou em `gameRules/npc/movement.ts` — "atrás" é o lado oposto ao que o jogador encara, sempre clampado em `BATTLE_LIMITS`, porque teleportar para fora da arena deixaria o boss inalcançável.

`mauraoPhase2` usa isso **só na transição ocioso → girando**. Já girando, o `x` continua saindo da perseguição normal: o boss não pisca a cada hit do giro.

## Screenshots

**Descrição do Screenshot**:

1. Batalha contra o Maurão rodando no `/battle/tester/maurao` (1400x900) após a mudança: HUD, fase 1 e o caminho de bloqueio funcionando, `108/108` de vida do boss.
2. A fase 2 exige zerar a vida do boss uma vez (`useLifecycle` só troca de fase em `npcHP <= 0`), o que não é alcançável com personagem nv.1 dentro da sessão de validação — o teleport foi verificado chamando `mauraoPhase2` direto (ver abaixo), não por captura de tela.

## Outras mudanças

- Docstring em `mauraoPhase2` descrevendo o ciclo do giro, substituindo o comentário inline `// idle — check if ready to start spinning`.

## Notas sobre deploy

Nada a fazer no deploy: build normal.

**Validação local executada**:
- `npm run type-check` — só os 5 erros pré-existentes de `gathering.ts`.
- `npx eslint src/gameRules/battle/babidiBlock.ts src/gameRules/npc/movement.ts src/services/npc/attacks/maurao src/hooks/battle/npc src/hooks/battle/useSystem.ts` — limpo.
- Harness determinístico (bundle via `esbuild` + `node`) exercitando as regras puras, **13 checks, todos verdes**:
  - `getBehindPlayerX`: espelha pela direção do jogador e clampa nos dois limites da arena;
  - `mauraoPhase2`: teleporta para `playerX - 70` com jogador virado à direita, `playerX + 70` virado à esquerda, e **não** reposiciona nos ticks seguintes do giro;
  - `getBabidiBlockReflect`: `null` para outro personagem e para dano 0; 5% no mesmo nível; 2x com +10 níveis; 3x com +20; instakill acima de 20 devolvendo a vida restante; piso de 5% em desvantagem.
- Playwright MCP: batalha `/battle/tester/maurao` carregada e jogada em 1400x900. O único erro de console é o `setState-in-render` de `TitleProvider`/`BattleScene`, reproduzido também em worktree sem estas mudanças.

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma

---

## Validação completa (rodada dedicada)

**Estático**
- `npm run type-check`: 5 erros, todos herdados de `gathering.ts` na `main`. Zero nos arquivos desta branch.
- `npx eslint .` (projeto inteiro): limpo.
- `npx vite build` + `npm run build:sw`: exit 0 nos dois.
- Harness determinístico: **13 checks verdes** (re-rodado).

**Browser (Playwright MCP, 1400x900, Babidi nv.40 semeado via localStorage)**

**Babidi Block — reflexo confirmado ao vivo.** Segurando bloqueio, **sem atacar**, a vida do Maurão caiu em passos de exatamente **2**: `318 → 316 → 314 → 312 → 310 → 308 → 306`, e depois `306 → 294`. O golpe bloqueado do boss valia 38 de dano (número visto quando não bloqueado); 5% de 38 = 1,9 → **2**, com diferença de nível ~0 entre jogador e boss. Bate com a regra.

**Fase 2 do Maurão — teleport dispara.** Fase 2 alcançada (50% de progresso na tela de resultado, sprites `phase2/startSpin|inSpin|finishSpin|idle`). Em **todas** as transições `idle → startSpin` capturadas, a posição do boss muda de forma descontínua num único frame de amostragem (100ms), depois de ter ficado estática por segundos durante o ocioso — é o teleport executando. O boss aparece do lado oposto ao que o jogador encara.

Limite honesto desta medição: a **distância exata** (`SPIN_TELEPORT_OFFSET = 70`) não é verificável por pixel na tela. O container do NPC posiciona por `left: x * scaleX` mas o sprite dentro dele usa `TILE_SIZE * sizeMultiplier`, então converter retângulo de tela em coordenada de jogo embute o offset do anchor. A escala do mapa foi medida (0,982 px por unidade, andando de `BATTLE_LIMITS.minX` a `maxX`), mas o anchor do sprite do boss não. Quem fixa o valor exato é o harness, que chama `mauraoPhase2` direto e confere `playerX ± 70`, o clamp nos dois limites da arena e a ausência de reposicionamento nos ticks seguintes.

`browser_console_messages`: só o `setState-in-render` de `TitleProvider`/`BattleScene`, reproduzido também em worktree sem estas mudanças.

## Achados desta validação

### 1. Corrigido aqui: número de dano refletido saía com o estilo errado

`TYPE_CLASS` em `components/Game/Battle/Effects/DamageNumbers` não tinha entrada para `reflect`, então caía no fallback `styles.npc` — **vermelho, a cor de dano que o jogador sofre**. O reflexo aparecia como se o golpe tivesse acertado o jogador. Ganhou cor própria (roxo `#7c4dff`), confirmado no browser: o número do reflexo sai em `rgb(124, 77, 255)`, ao lado do `BLOCKED!` ciano, enquanto o dano do boss segue vermelho.

O tipo `reflect` já era usado pelo reflexo de equipamento (`useNpc.ts:112`) — o defeito é anterior a este PR; o Babidi Block só tornou o caso frequente.

### 2. Não corrigido: o instakill do #111 é inalcançável hoje

`generateNpcLevel` (`src/gameRules/battle/generateNpcLevel.ts`) sorteia o nível do NPC **sempre dentro de ±3 do nível do jogador**, e é o único produtor de `npcLevel` no jogo (via `useNpcSetup`, chamado só em `useScene`). Logo:

- a diferença de nível a favor do jogador nunca passa de **3**;
- o multiplicador de reflexo fica na faixa **1.0x – 1.3x**;
- a cláusula "mais de 20 níveis de diferença = instakill" **nunca dispara em jogo real**, embora esteja implementada e coberta por teste.

Não mudei balanceamento por conta própria. Os caminhos possíveis, para você escolher:

1. **NPC com nível fixo** para bosses/npcs específicos (hoje todo encontro escala com o jogador) — aí a diferença de 20 níveis passa a existir;
2. **medir a diferença contra outra coisa** que não o nível sorteado — classe do NPC (`common`…`legendary`) ou dificuldade;
3. **deixar como está**, tratando o instakill como regra que só vale se/quando existir NPC de nível fixo.
