### PR TITLE
fix: destravar o build importando DefeatMenuSelection do módulo de tipo

### DIFF
--- a/src/components/Game/Battle/Modal/Defeat/index.tsx
+++ b/src/components/Game/Battle/Modal/Defeat/index.tsx
@@ -8,10 +8,8 @@ import { formatDuration } from "@/utils/formatDuration";
 import { playerPath } from "@/utils/paths";
 import { ActivePotionDisplay } from "@/components/Game/Battle/ActivePotionDisplay";
 import { FleeButton } from "@/components/Game/Battle/Buttons/Run";
-import {
-  useDefeatCharacterSelect,
-  type DefeatMenuSelection,
-} from "@/hooks/battle/defeat/useDefeatCharacterSelect";
+import { useDefeatCharacterSelect } from "@/hooks/battle/defeat/useDefeatCharacterSelect";
+import type { DefeatMenuSelection } from "@/utils/types/battle/defeat";
 
 type Props = {
   isOpen: boolean;


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - `main` está com o `tsc -b` quebrado. Este PR destrava o build e é pré-requisito dos demais PRs abertos hoje.

## Problema

`npm run type-check` falha na `main`:

```
src/components/Game/Battle/Modal/Defeat/index.tsx(13,8): error TS2459: Module '"@/hooks/battle/defeat/useDefeatCharacterSelect"' declares 'DefeatMenuSelection' locally, but it is not exported.
```

O modal de derrota importava `DefeatMenuSelection` do hook `useDefeatCharacterSelect`, mas o hook apenas **consome** esse tipo (`import type { DefeatMenuSelection, View } from "@/utils/types/battle/defeat"`) e não o re-exporta. Com `verbatimModuleSyntax`, isso é erro de compilação.

## Solução

Importar o tipo direto do módulo dono dele, `@/utils/types/battle/defeat`, que é onde a convenção do `AGENTS.md` manda tipos de domínio morarem. O import do hook fica só com o hook.

## Screenshots

**Descrição do Screenshot**:
Não se aplica — correção de tipo, sem efeito em runtime nem em pixel.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Sem passo de deploy. Nenhum comportamento de runtime muda — só o import type.

**Validação local executada**:
- `npm run type-check` → verde (na `main` falhava com o TS2459 acima)
- `npx eslint src/components/Game/Battle/Modal/Defeat/index.tsx` → sem achados

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
