### PR TITLE
fix: salvar o replay da última tentativa da batalha

### DIFF
--- a/src/hooks/battle/useScene.ts
+++ b/src/hooks/battle/useScene.ts
@@ -1188,6 +1188,7 @@ export function useBattleScene({
     if (grabbedTimerRef.current) clearTimeout(grabbedTimerRef.current);
     grabbedTimerRef.current = null;
     setIsGrabbed(false);
+    startRecording();
   }
 
   return {


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - O `tsc -b` só fica verde com o #198 mergeado — a `main` está com um TS2459 pré-existente no modal de derrota, sem relação com este PR.

Closes #32

## Problema

O replay salvo na vitória era o da **primeira** tentativa da batalha, não o da última.

A gravação é ligada por um único efeito em `src/hooks/battle/useScene.ts`, na transição intro → batalha:

```ts
useEffect(() => {
  if (wasIntroActiveRef.current && !showIntro) {
    startRecording();
  }
  wasIntroActiveRef.current = showIntro;
}, [showIntro, startRecording]);
```

Na derrota, o efeito seguinte chama `stopRecording()`. Quando o jogador aperta "Tentar novamente", `handleRetry` reseta batalha, NPC, combo, summons, timers — mas **não** religa a gravação, e `showIntro` não volta a ficar `true`, então aquele efeito nunca dispara de novo.

Consequência: `framesRef` continua com os frames da tentativa que terminou em derrota, o intervalo de captura está parado, e o botão "Salvar Replay" da vitória persiste exatamente a tentativa perdida. Quanto mais tentativas, mais velho o replay salvo.

## Solução

`handleRetry` passa a chamar `startRecording()` no fim do reset.

`startRecording` já é idempotente (`if (isRecording) return`) e já faz o trabalho todo de reinício: zera `framesRef`, redefine `startTimestampRef`, remonta o metadata e chama `initAudioLog(...)` — então a tentativa nova nasce com frames e log de áudio limpos, e o `getReplayData()`/`getReplayWindow()` da vitória passa a enxergar só a última tentativa.

## Screenshots

**Descrição do Screenshot**:
Não se aplica — a mudança é de gravação de estado, sem alteração visual.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Sem passo de deploy. Replays já salvos no `localStorage` continuam válidos e legíveis — o formato não mudou.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (corrigido no #198)
- `npx eslint src/hooks/battle/useScene.ts` → sem achados

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
