### PR TITLE
feat: planilha de tipagens na aba de batalha

### DIFF
--- a/src/components/Game/Navbar/ExploreNavbar/Config/BattleTab/ElementChart/index.tsx
+++ b/src/components/Game/Navbar/ExploreNavbar/Config/BattleTab/ElementChart/index.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import { getElementChart } from "@/gameRules/battle/elementRelations";
+import type { ElementType } from "@/utils/types/battle/element";
+import styles from "./styles.module.css";
+
+function ElementCell({ elements }: { elements: ElementType[] }) {
+  if (elements.length === 0) return <span className={styles.none}>—</span>;
+
+  return (
+    <span className={styles.list}>
+      {elements.map((element) => (
+        <span key={element} className={styles.tag}>
+          {element}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function ElementChart() {
+  const chart = useMemo(() => getElementChart(), []);
+
+  return (
+    <section className={styles.container}>
+      <h2 className={styles.title}>Tabela de tipagens</h2>
+
+      <div className={styles.scroll}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th scope="col">Tipagem</th>
+              <th scope="col" className={styles.superHeader}>
+                Super efetivo (1.5x)
+              </th>
+              <th scope="col">Dano normal (1x)</th>
+              <th scope="col" className={styles.weakHeader}>
+                Não efetivo (0.5x)
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {chart.map((row) => (
+              <tr key={row.attacker}>
+                <th scope="row" className={styles.attacker}>
+                  {row.attacker}
+                </th>
+                <td className={styles.superCell}>
+                  <ElementCell elements={row.superEffective} />
+                </td>
+                <td>
+                  <ElementCell elements={row.normal} />
+                </td>
+                <td className={styles.weakCell}>
+                  <ElementCell elements={row.notEffective} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Game/Navbar/ExploreNavbar/Config/BattleTab/ElementChart/styles.module.css
+++ b/src/components/Game/Navbar/ExploreNavbar/Config/BattleTab/ElementChart/styles.module.css
@@ -1,0 +1,75 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-8);
+  width: 100%;
+}
+
+.title {
+  text-align: center;
+}
+
+.scroll {
+  overflow-x: auto;
+  width: 100%;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: var(--fs-14);
+  color: var(--text-color);
+}
+
+.table th,
+.table td {
+  border: var(--size-2) solid var(--primary-color);
+  padding: var(--fs-8);
+  text-align: left;
+  vertical-align: top;
+}
+
+.table thead th {
+  text-align: center;
+  text-wrap: nowrap;
+}
+
+.attacker {
+  text-wrap: nowrap;
+}
+
+.superHeader {
+  color: var(--success);
+}
+
+.weakHeader {
+  color: var(--danger);
+}
+
+.list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-4);
+}
+
+.tag {
+  border: var(--size-1) solid var(--border-default);
+  border-radius: var(--size-4);
+  padding: 0 var(--fs-6);
+  color: var(--text-color);
+  text-wrap: nowrap;
+}
+
+.superCell .tag {
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.weakCell .tag {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.none {
+  color: var(--text-hint);
+}

--- a/src/components/Game/Navbar/ExploreNavbar/Config/BattleTab/index.tsx
+++ b/src/components/Game/Navbar/ExploreNavbar/Config/BattleTab/index.tsx
@@ -3,6 +3,7 @@ import { usePlayer } from "@/contexts/PlayerContext";
 import { useNavigate } from "react-router";
 import { useBattleInfo } from "@/contexts/BattleInfoContext";
 import { CardRedeem } from "./CardRedeem";
+import { ElementChart } from "./ElementChart";
 
 type Props = {
   showComboAction: boolean;
@@ -56,6 +57,8 @@ export function BattleTab({
           <CardRedeem isSelected={selectedIndex === 3} />
         </>
       )}
+
+      <ElementChart />
     </div>
   );
 }

--- a/src/gameRules/battle/elementRelations.ts
+++ b/src/gameRules/battle/elementRelations.ts
@@ -1,0 +1,47 @@
+import { ELEMENT_STRONG_AGAINST } from "@/data/types/elementChart";
+import { combatService } from "@/services/combat";
+import type { ElementType } from "@/utils/types/battle/element";
+
+export const ELEMENT_TYPES = Object.keys(
+  ELEMENT_STRONG_AGAINST,
+) as ElementType[];
+
+export type ElementRelations = {
+  attacker: ElementType;
+  superEffective: ElementType[];
+  normal: ElementType[];
+  notEffective: ElementType[];
+};
+
+/**
+ * Classifica todo defensor pelo multiplicador que o atacante recebe contra
+ * ele, usando o mesmo `combatService.getElementMultiplier` do combate — a
+ * planilha não pode divergir do dano real, então nenhuma regra é reescrita
+ * aqui.
+ */
+export function getElementRelations(attacker: ElementType): ElementRelations {
+  const superEffective: ElementType[] = [];
+  const normal: ElementType[] = [];
+  const notEffective: ElementType[] = [];
+
+  for (const defender of ELEMENT_TYPES) {
+    const multiplier = combatService.getElementMultiplier(
+      [attacker],
+      [defender],
+    );
+
+    if (multiplier > 1) {
+      superEffective.push(defender);
+    } else if (multiplier < 1) {
+      notEffective.push(defender);
+    } else {
+      normal.push(defender);
+    }
+  }
+
+  return { attacker, superEffective, normal, notEffective };
+}
+
+export function getElementChart(): ElementRelations[] {
+  return ELEMENT_TYPES.map(getElementRelations);
+}


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - A planilha não reimplementa a regra de tipagem: ela chama `combatService.getElementMultiplier()`, o mesmo método que o combate usa. Se o multiplicador mudar, a tabela muda junto.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #20

## Problema

O jogador não tinha onde consultar as vantagens de tipagem. A informação existia só no código (`ELEMENT_STRONG_AGAINST` / `ELEMENT_WEAK_AGAINST`) e na tentativa e erro dentro da batalha, com 15 tipagens para memorizar.

## Solução

### `src/gameRules/battle/elementRelations.ts`

Classifica cada defensor pelo multiplicador real:

```ts
const multiplier = combatService.getElementMultiplier([attacker], [defender]);
if (multiplier > 1) superEffective.push(defender);
else if (multiplier < 1) notEffective.push(defender);
else normal.push(defender);
```

Consultar o serviço em vez de ler as duas tabelas na mão importa por um caso concreto: `getElementMultiplier` testa vantagem **antes** de desvantagem, então em par de vantagem mútua (Darkus × Haos, por design) o resultado é 1.5x nas duas direções. Uma planilha escrita a partir de `ELEMENT_WEAK_AGAINST` mostraria Haos como "não efetivo" contra Darkus — e ensinaria o oposto do dano que o jogador leva.

### `ElementChart` no `BattleTab`

Uma linha por tipagem atacante e três colunas: **Super efetivo (1.5x)**, **Dano normal (1x)**, **Não efetivo (0.5x)**. Tag verde na coluna de vantagem, vermelha na de desvantagem, `—` quando a lista é vazia (Normalis não tem vantagem contra ninguém; Umbra não tem desvantagem).

Renderizada fora do bloco `!battleInfo && !isInBattle`, então a tabela também fica acessível com a batalha em andamento — que é quando ela serve para alguma coisa.

## Screenshots

**Descrição do Screenshot**:
Validado com o Playwright MCP no dev server, aba Configurações → Batalha:

- **Desktop (1280×800)**: tabela completa, colunas legíveis, tags coloridas por efetividade. As 15 linhas são alcançadas pelo scroll do próprio painel (`scrollHeight` 1698 / `clientHeight` 720).
- **Mobile (390×844)**: a tabela mede 1500px, exatamente a largura do layout do jogo — ou seja, **não** introduz overflow horizontal novo; o scroll lateral que aparece no retrato é o do app inteiro, que já existia antes deste PR.
- `browser_console_messages` nível `error`: **0 erros**.

Primeira versão usava `--fs-12` sem `color`, e as tags ficaram ilegíveis sobre o fundo escuro — ajustado para `--fs-14` com `var(--text-color)` e o realce por coluna, que é o que está no PR.

## Outras mudanças

- `ELEMENT_TYPES` exportado em `elementRelations.ts`, derivado das chaves de `ELEMENT_STRONG_AGAINST` — evita repetir a união `ElementType` como array em outro lugar.

## Notas sobre deploy

Sem passo de deploy, sem migração, sem asset novo.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint` nos arquivos tocados → sem achados
- Playwright MCP: navegação até a aba, screenshots desktop/mobile, medição de overflow e console

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
