### PR TITLE
feat: papers piscam antes de explodir na batalha do maugrelo

### DIFF
--- a/src/components/Game/Battle/Entities/GroundPaper/index.tsx
+++ b/src/components/Game/Battle/Entities/GroundPaper/index.tsx
@@ -7,6 +7,8 @@ import type {
 } from "@/services/npc/attacks/maugrelo/state";
 import type { BattleEntityPositioning } from "../types";
 
+import styles from "./styles.module.css";
+
 type Props = BattleEntityPositioning & {
   papers: GroundPaperState[];
   flyingPaper: FlyingPaper | null;
@@ -58,6 +60,9 @@ export function GroundPaper({
       {papers.map((gp) => (
         <img
           key={gp.id}
+          className={
+            gp.sprite === "paper" && gp.armedAt != null ? styles.blink : ""
+          }
           src={
             gp.sprite === "explosion"
               ? npcPathProjectile("/explosion.svg")

--- a/src/components/Game/Battle/Entities/GroundPaper/styles.module.css
+++ b/src/components/Game/Battle/Entities/GroundPaper/styles.module.css
@@ -1,0 +1,13 @@
+.blink {
+  animation: paperBlink 500ms steps(1, end) infinite;
+}
+
+@keyframes paperBlink {
+  0% {
+    filter: none;
+  }
+
+  50% {
+    filter: brightness(0) invert(1);
+  }
+}

--- a/src/components/Game/Battle/Entities/StuckPapers/index.tsx
+++ b/src/components/Game/Battle/Entities/StuckPapers/index.tsx
@@ -3,6 +3,8 @@ import { STUCK_EXPLOSION_DISAPPEAR_MS } from "@/services/npc/attacks/maugrelo/st
 import type { StuckPaper } from "@/services/npc/attacks/maugrelo/state";
 import type { BattleEntityPositioning } from "../types";
 
+import styles from "./styles.module.css";
+
 type Props = BattleEntityPositioning & {
   papers: StuckPaper[];
   playerX: number;
@@ -28,6 +30,7 @@ export function StuckPapers({
         return (
           <img
             key={sp.id}
+            className={exploding ? "" : styles.blink}
             src={
               exploding
                 ? npcPathProjectile("/explosion.svg")

--- a/src/components/Game/Battle/Entities/StuckPapers/styles.module.css
+++ b/src/components/Game/Battle/Entities/StuckPapers/styles.module.css
@@ -1,0 +1,13 @@
+.blink {
+  animation: paperBlink 500ms steps(1, end) infinite;
+}
+
+@keyframes paperBlink {
+  0% {
+    filter: none;
+  }
+
+  50% {
+    filter: brightness(0) invert(1);
+  }
+}

--- a/src/services/npc/attacks/maugrelo/papers.ts
+++ b/src/services/npc/attacks/maugrelo/papers.ts
@@ -8,6 +8,7 @@ import {
   PAPER_VEL_X_SPREAD,
   PAPER_MIN_DISTANCE,
   PAPER_EXPLOSION_DURATION,
+  PAPER_BLINK_DURATION,
   PAPER_STEP_RADIUS,
   PAPER_STEP_VERTICAL_RANGE,
   PAPER_ATTACK_RANGE,
@@ -92,6 +93,12 @@ export function cleanupExplosions(ai: MaugreloAI, now: number) {
   });
 }
 
+/**
+ * Pisar num papel **arma** o papel em vez de explodi-lo: ele fica piscando por
+ * `PAPER_BLINK_DURATION` e só então `updateArmedPapers` troca para
+ * explosion.svg e aplica o dano. É essa janela que permite ao jogador desarmar
+ * o papel com um ataque (`checkPaperAttackHits`) antes de levar dano.
+ */
 export function checkGroundPaperHits(
   ai: MaugreloAI,
   playerX: number,
@@ -105,17 +112,48 @@ export function checkGroundPaperHits(
 
   for (const gp of allPapers) {
     if (gp.sprite === "explosion") continue;
-    if (gp.id === ai.lastPaperHitId) continue;
+    if (gp.armedAt != null) continue;
 
     const dx = Math.abs(playerX - gp.x);
     const dy = Math.abs(playerY - gp.y);
 
     if (dx < PAPER_STEP_RADIUS && dy <= PAPER_STEP_VERTICAL_RANGE) {
-      gp.sprite = "explosion";
-      gp.createdAt = now;
-      ai.lastPaperHitId = gp.id;
-      onGroundPaperHit();
+      gp.armedAt = now;
       break;
+    }
+  }
+}
+
+/**
+ * Fecha o ciclo do papel armado: terminada a piscada, o papel vira
+ * explosion.svg. O dano só sai se o jogador ainda estiver em cima do papel no
+ * instante da explosão — sair de perto é a segunda forma de escapar, ao lado
+ * de desarmar o papel com um ataque. Papel desarmado a tempo já está com
+ * `sprite === "explosion"` e não chega aqui.
+ */
+export function updateArmedPapers(
+  ai: MaugreloAI,
+  playerX: number,
+  playerY: number,
+  onGroundPaperHit: (() => void) | undefined,
+  now: number,
+) {
+  const allPapers = [...ai.groundPapers, ...ai.landedPapers];
+
+  for (const gp of allPapers) {
+    if (gp.sprite !== "paper") continue;
+    if (gp.armedAt == null) continue;
+    if (now - gp.armedAt < PAPER_BLINK_DURATION) continue;
+
+    gp.sprite = "explosion";
+    gp.createdAt = now;
+    ai.lastPaperHitId = gp.id;
+
+    const dx = Math.abs(playerX - gp.x);
+    const dy = Math.abs(playerY - gp.y);
+
+    if (dx < PAPER_STEP_RADIUS && dy <= PAPER_STEP_VERTICAL_RANGE) {
+      onGroundPaperHit?.();
     }
   }
 }

--- a/src/services/npc/attacks/maugrelo/phase1.ts
+++ b/src/services/npc/attacks/maugrelo/phase1.ts
@@ -7,6 +7,7 @@ import {
   updateFlyingPaper,
   cleanupExplosions,
   checkGroundPaperHits,
+  updateArmedPapers,
   checkPaperAttackHits,
 } from "./papers";
 import {
@@ -40,6 +41,7 @@ export function maugreloPhase1(
   updateFlyingPaper(ai);
   cleanupExplosions(ai, now);
   checkGroundPaperHits(ai, playerX, playerY, onGroundPaperHit, now);
+  updateArmedPapers(ai, playerX, playerY, onGroundPaperHit, now);
   checkPaperAttackHits(
     ai,
     playerX,

--- a/src/services/npc/attacks/maugrelo/phase2/index.ts
+++ b/src/services/npc/attacks/maugrelo/phase2/index.ts
@@ -15,6 +15,7 @@ import {
 import {
   cleanupExplosions,
   checkGroundPaperHits,
+  updateArmedPapers,
   checkPaperAttackHits,
   updateStuckPapers,
 } from "../papers";
@@ -42,6 +43,7 @@ export function maugreloPhase2(
     ctx.onGroundPaperHit,
     now,
   );
+  updateArmedPapers(ai, ctx.playerX, ctx.playerY, ctx.onGroundPaperHit, now);
   checkPaperAttackHits(
     ai,
     ctx.playerX,

--- a/src/services/npc/attacks/maugrelo/state.ts
+++ b/src/services/npc/attacks/maugrelo/state.ts
@@ -8,6 +8,7 @@ import {
   EIGHT_HUNDRED_MS,
   ONE_THOUSAND_TWO_HUNDRED_MS,
   ONE_THOUSAND_FIVE_HUNDRED_MS,
+  TWO_THOUSAND_MS,
   THREE_THOUSAND_MS,
   FIVE_THOUSAND_MS,
   EIGHT_THOUSAND_MS,
@@ -20,6 +21,8 @@ export type GroundPaper = {
   y: number;
   sprite: "paper" | "explosion";
   createdAt: number;
+  /** Quando o papel foi armado (pisado). undefined = ainda inerte. */
+  armedAt?: number;
 };
 
 export type StuckPaper = {
@@ -121,6 +124,8 @@ export const PAPER_X_SPREAD = 60;
 export const PAPER_VEL_X_SPREAD = 1.5;
 export const PAPER_MIN_DISTANCE = 50;
 export const PAPER_EXPLOSION_DURATION = FIVE_HUNDRED_MS;
+/** Tempo que o papel pisado pisca antes de virar explosion.svg e causar dano. */
+export const PAPER_BLINK_DURATION = TWO_THOUSAND_MS;
 export const PAPER_STEP_RADIUS = 30;
 /**
  * Tolerância vertical (eixo Y) para o papel explodir quando o jogador pisa.


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - **Mudança de balanceamento na luta do Maugrelo**: pisar num papel deixa de causar dano imediato. O dano agora sai 2s depois, e só se o jogador ainda estiver em cima do papel.
> - A decisão de checar a posição do jogador **no instante da explosão** não está escrita na issue — está justificada abaixo. Se a intenção era dano garantido, é uma linha para tirar.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #194

## Problema

`checkGroundPaperHits` explodia o papel no mesmo frame do passo:

```ts
if (dx < PAPER_STEP_RADIUS && dy <= PAPER_STEP_VERTICAL_RANGE) {
  gp.sprite = "explosion";
  gp.createdAt = now;
  ai.lastPaperHitId = gp.id;
  onGroundPaperHit();   // dano
  break;
}
```

Sem janela nenhuma: encostou, levou. Os `stuckPapers` já esperavam `STUCK_PAPER_DURATION` (3s) antes de explodir, mas nada sinalizava essa contagem para o jogador — o papel ficava parado igual e explodia do nada.

## Solução

### Papel do chão: armar em vez de explodir

`checkGroundPaperHits` agora só marca `gp.armedAt = now`. Quem fecha o ciclo é a função nova `updateArmedPapers`, chamada nas duas fases (`phase1.ts` e `phase2/index.ts`), que depois de `PAPER_BLINK_DURATION` (2s) troca para `explosion.svg`.

Duas saídas para o jogador, que é o ponto da issue:

1. **Desarmar** — atacar o papel durante a piscada. `checkPaperAttackHits` já fazia isso; o que destravou foi parar de escrever `lastPaperHitId` no passo. Antes, o papel pisado entrava justamente no `id === ai.lastPaperHitId` do ataque e ficava imune a ser desarmado. O guard do passo virou `gp.armedAt != null`, que é o estado que ele de fato quer testar.
2. **Sair de cima** — o dano é condicionado ao jogador ainda estar dentro de `PAPER_STEP_RADIUS`/`PAPER_STEP_VERTICAL_RANGE` na hora da explosão. A issue nomeia só o desarme, mas dano teleguiado em quem já saiu de perto contradiz "evite o dano de forma mais fácil"; deixei explícito aqui porque é decisão de design, não detalhe.

### Piscada

CSS module com `animation: paperBlink 500ms steps(1, end) infinite` alternando `filter: none` e `filter: brightness(0) invert(1)` — o sprite fica **totalmente branco** e volta, 4 piscadas nos 2s do papel do chão e 6 nos 3s do `stuckPaper`. `steps(1, end)` para o corte ser seco, não um fade.

Aplicada no `GroundPaper` quando `sprite === "paper" && armedAt != null`, e no `StuckPapers` enquanto o papel não está explodindo — cobrindo os dois casos que a issue pede.

## Screenshots

**Descrição do Screenshot**:
Validado com o Playwright MCP na batalha real (`#/battle/tester/maugrelo`, 1280×800):

- A regra `_blink_…` e o `@keyframes paperBlink` carregam na página.
- Amostrando `getComputedStyle(paper).filter` a cada 130ms com a classe aplicada: `brightness(1) invert(0)` → `brightness(0) invert(1)` → … — a alternância acontece de verdade, no ciclo de 500ms.
- Screenshot com o papel na metade branca do ciclo: o sprite fica sólido branco sobre o piso escuro, bem legível como aviso.

O encadeamento de estados foi validado fora do browser, com as próprias funções bundladas pelo esbuild (`--alias:@=./src`), porque dirigir a luta do boss até o passo certo no papel não é reproduzível:

```
step: armedAt=true sprite=paper damage=0
before blink ends: sprite=paper damage=0
after blink (player on it): sprite=explosion damage=1
after blink (player away): sprite=explosion damage=0
defused by attack: sprite=explosion defused=1 damage=0
```

## Outras mudanças

- `PAPER_BLINK_DURATION` e o campo `armedAt` documentados em `state.ts`.

## Notas sobre deploy

Sem passo de deploy. Nenhum asset novo — reusa `paper.svg` e `explosion.svg`.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint` nos arquivos tocados → sem achados
- Playwright MCP + harness esbuild (saídas acima)

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
