### PR TITLE
feat: pular cutscene segurando L por 3s

### DIFF
--- a/src/hooks/game/useGameKeyboard.ts
+++ b/src/hooks/game/useGameKeyboard.ts
@@ -9,6 +9,17 @@ import {
   SCREEN_SHORTCUT_KEYS,
 } from "@/data/keyActions";
 
+/**
+ * Ações em que o auto-repeat do teclado não pode virar repetição.
+ *
+ * Segurar `L` disparava `onConfirm` dezenas de vezes por segundo, o que
+ * atropelava diálogo inteiro em menos de um segundo e tornava impossível
+ * distinguir um toque de um toque longo — que é o gesto de pular cutscene.
+ * Direcional fica de fora de propósito: repetir é o comportamento
+ * esperado ao segurar a seta num menu ou na batalha.
+ */
+const NO_AUTO_REPEAT_ACTIONS = new Set(["onConfirm", "onCancel"]);
+
 type GameKeyboardOptions = {
   controlsRef: RefObject<GameControlLayer>;
   playerModeRef: RefObject<string>;
@@ -45,6 +56,7 @@ export function useGameKeyboard({
       const action = KEY_ACTIONS[e.key];
 
       if (action) {
+        if (e.repeat && NO_AUTO_REPEAT_ACTIONS.has(action)) return;
         controls[action]?.();
         return;
       }

--- a/src/hooks/interaction/useCutscene.ts
+++ b/src/hooks/interaction/useCutscene.ts
@@ -1,8 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useGameControls } from "@/contexts/GameControlsContext";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import { useDialogue } from "@/hooks/interaction/useDialogue";
 import { usePlayer } from "@/contexts/PlayerContext";
+import { THREE_THOUSAND_MS } from "@/data/ms";
+
+/** Tempo de `L` pressionado que abre o prompt de pular a cutscene. */
+export const CUTSCENE_SKIP_HOLD_MS = THREE_THOUSAND_MS;
 
 type Props = {
   dialogue: Parameters<typeof useDialogue>[0];
@@ -26,6 +30,17 @@ export function useCutscene({
   const { pushControls } = useGameControls();
 
   const hasPlayed = useRef(false);
+
+  const [isSkipPromptOpen, setIsSkipPromptOpen] = useState(false);
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHoldTimer = useCallback(() => {
+    if (!holdTimerRef.current) return;
+    clearTimeout(holdTimerRef.current);
+    holdTimerRef.current = null;
+  }, []);
+
+  useEffect(() => clearHoldTimer, [clearHoldTimer]);
 
   const dialogueSystemRef = useLatestRef(dialogueSystem);
   const playAudioRef = useLatestRef(playAudio);
@@ -61,6 +76,22 @@ export function useCutscene({
     }
   };
 
+  const dialogueSkipRef = useLatestRef(dialogueSystem.skip);
+
+  /**
+   * Confirma o pulo: corta o diálogo restante e dispara o término da
+   * cutscene, o mesmo caminho de quem assistiu até a última fala.
+   */
+  const confirmSkip = useCallback(() => {
+    setIsSkipPromptOpen(false);
+    clearHoldTimer();
+    dialogueSkipRef.current();
+  }, [clearHoldTimer, dialogueSkipRef]);
+
+  const cancelSkip = useCallback(() => {
+    setIsSkipPromptOpen(false);
+  }, []);
+
   const pushControlsRef = useLatestRef(pushControls);
 
   // 🔥 CORREÇÃO AQUI
@@ -70,14 +101,28 @@ export function useCutscene({
     if (player.mode === "ui") return;
 
     const remove = pushControlsRef.current({
-      onConfirm: () => handleConfirmRef.current(),
+      onConfirm: () => {
+        handleConfirmRef.current();
+        clearHoldTimer();
+        holdTimerRef.current = setTimeout(() => {
+          holdTimerRef.current = null;
+          setIsSkipPromptOpen(true);
+        }, CUTSCENE_SKIP_HOLD_MS);
+      },
+      onConfirmRelease: () => clearHoldTimer(),
     });
 
-    return () => remove();
-  }, [dialogueSystem.isOpen, player.mode, pushControlsRef]);
+    return () => {
+      clearHoldTimer();
+      remove();
+    };
+  }, [dialogueSystem.isOpen, player.mode, pushControlsRef, clearHoldTimer]);
 
   return {
     ...dialogueSystem,
     hasPlayed: hasPlayed.current,
+    isSkipPromptOpen,
+    confirmSkip,
+    cancelSkip,
   };
 }

--- a/src/hooks/interaction/useDialogue.ts
+++ b/src/hooks/interaction/useDialogue.ts
@@ -51,22 +51,36 @@ export function useDialogue(dialogues: Dialogue[], onFinish?: () => void) {
     [],
   );
 
+  /**
+   * Encerra o diálogo e dispara o callback de término correspondente — o do
+   * sub-diálogo quando há um em curso, senão o `onFinish` do diálogo raiz.
+   */
+  const finish = useCallback(() => {
+    setIsOpen(false);
+    const wasSubDialogue = customDialoguesRef.current !== null;
+    const customOnFinish = customOnFinishRef.current;
+    setCustomDialogues(null);
+    customOnFinishRef.current = null;
+    if (wasSubDialogue) {
+      customOnFinish?.();
+    } else {
+      onFinish?.();
+    }
+  }, [onFinish, customDialoguesRef]);
+
   const next = useCallback(() => {
     if (index >= processedDialogues.length - 1) {
-      setIsOpen(false);
-      const wasSubDialogue = customDialoguesRef.current !== null;
-      const customOnFinish = customOnFinishRef.current;
-      setCustomDialogues(null);
-      customOnFinishRef.current = null;
-      if (wasSubDialogue) {
-        customOnFinish?.();
-      } else {
-        onFinish?.();
-      }
+      finish();
       return;
     }
     setIndex((prev) => prev + 1);
-  }, [index, processedDialogues.length, onFinish, customDialoguesRef]);
+  }, [index, processedDialogues.length, finish]);
+
+  /** Corta o diálogo restante e vai direto para o término. */
+  const skip = useCallback(() => {
+    setIndex(0);
+    finish();
+  }, [finish]);
 
   const dialogue = useMemo(() => {
     return processedDialogues[index];
@@ -87,6 +101,7 @@ export function useDialogue(dialogues: Dialogue[], onFinish?: () => void) {
       isOpen,
       start,
       next,
+      skip,
       isLast,
       index,
       length: processedDialogues.length,
@@ -97,6 +112,7 @@ export function useDialogue(dialogues: Dialogue[], onFinish?: () => void) {
       isOpen,
       start,
       next,
+      skip,
       isLast,
       index,
       processedDialogues.length,

--- a/src/pages/CombatTutorial/index.tsx
+++ b/src/pages/CombatTutorial/index.tsx
@@ -3,6 +3,7 @@ import { useCombatTasks } from "@/hooks/tutorial/useCombatTasks";
 import { useCutscene } from "@/hooks/interaction/useCutscene";
 import { npcPath } from "@/utils/paths";
 import Talking from "@/components/Game/Interactions/Talking";
+import { ChoiceBox } from "@/components/Game/Interactions/ChoiceBox";
 import { BattleScene } from "@/components/Game/Scenes/Battle";
 import { combatTutorialDialogue } from "@/data/dialogues/combatTutorial/one";
 import { TASKS } from "@/gameRules/tutorial/combatTasks";
@@ -30,6 +31,16 @@ export default function CombatTutorial() {
             name={dialogue.name}
             message={dialogue.message}
             src={dialogue.src}
+          />
+        )}
+
+        {cutscene.isSkipPromptOpen && (
+          <ChoiceBox
+            prompt="Tem certeza que deseja pular a cutscene?"
+            options={["Sim", "Não"]}
+            onSelect={(index) =>
+              index === 0 ? cutscene.confirmSkip() : cutscene.cancelSkip()
+            }
           />
         )}
       </div>

--- a/src/pages/Tutorial/index.tsx
+++ b/src/pages/Tutorial/index.tsx
@@ -98,6 +98,16 @@ export default function Tutorial() {
     >
       {dialogue && <Talking name={dialogue.name} message={dialogue.message} />}
 
+      {cutscene.isSkipPromptOpen && (
+        <ChoiceBox
+          prompt="Tem certeza que deseja pular a cutscene?"
+          options={["Sim", "Não"]}
+          onSelect={(index) =>
+            index === 0 ? cutscene.confirmSkip() : cutscene.cancelSkip()
+          }
+        />
+      )}
+
       {flow.showGenderChoice && (
         <ChoiceBox
           prompt="Você é macho ou fêmea?"


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Mudança de input **global**: segurar `L`/`Enter`/`B` deixa de repetir a ação. Direcional continua repetindo (menu e batalha dependem disso). Detalhe do porquê abaixo.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #33

## Problema

Não havia como pular cutscene. A issue pede: segurar `L` por 3s abre um modal de confirmação; "sim" pula, "não" volta.

Tentar isso direto esbarrava em duas coisas:

1. **Não existia "segurar"** — o `useCutscene` só registrava `onConfirm`, sem contraparte de release.
2. **Auto-repeat do teclado atropelava tudo** — `useGameKeyboard` chamava `controls[action]` a cada `keydown`, inclusive os sintéticos do auto-repeat (~30/s). Segurar `L` não era um toque longo: era o diálogo inteiro passando em menos de um segundo. Não sobrava cutscene para pular.

## Solução

### 1. Auto-repeat não repete confirmar/cancelar

```ts
if (action) {
  if (e.repeat && NO_AUTO_REPEAT_ACTIONS.has(action)) return;
  controls[action]?.();
  return;
}
```

`NO_AUTO_REPEAT_ACTIONS` cobre só `onConfirm` e `onCancel`. Direcional ficou de fora **de propósito**: repetir ao segurar a seta é o comportamento esperado num menu e na batalha. Efeito colateral bem-vindo fora da cutscene: segurar `L` não avança mais várias falas de uma vez em nenhum diálogo do jogo.

### 2. `skip()` no `useDialogue`

O corpo que fechava o diálogo e disparava o `onFinish` correto (o do sub-diálogo quando há um em curso, senão o da raiz) estava embutido no `next()`. Extraí para `finish()` e `skip()` reusa — pular passa exatamente pelo mesmo caminho de quem assistiu até a última fala, então quest, navegação e flags do `onFinish` continuam valendo.

### 3. Toque longo no `useCutscene`

A camada de controles da cutscene ganhou `onConfirmRelease`, e o `onConfirm` arma um timer de `CUTSCENE_SKIP_HOLD_MS` (3s) que abre o prompt. Ficar na camada de controles — e não num listener de teclado — faz o gesto valer **também no botão `L` da tela**, que dispara `onConfirm`/`onConfirmRelease` por `onPointerDown`/`onPointerUp`. Mobile ganha de graça.

### 4. Prompt

Reusa o `ChoiceBox` que já existe (mesma navegação e mesmo visual das outras escolhas do jogo) em vez de um modal novo. Ele empilha a própria camada de controles e consome o confirmar, então o `L` da resposta não vaza para o diálogo por baixo.

## Screenshots

**Descrição do Screenshot**:
Validado com o Playwright MCP no dev server, na `/tutorial`:

- Segurando `L` por 3,4s: aparece `Tem certeza que deseja pular a cutscene? | ▶ Sim | Não`, e a fala avançou **uma** vez só — a prova de que o auto-repeat parou de disparar `onConfirm` em rajada.
- **"Não"**: prompt fecha e a cutscene continua na mesma fala.
- **"Sim"**: a cutscene encerra e o jogo navega para `#/combatTutorial` — ou seja, o `onFinish` (que dá a quest `jomasio_investigate` e navega) rodou normalmente.
- `browser_console_messages` nível `error`: só dois `NotAllowedError: play() failed because the user didn't interact with the document first`, do autoplay em browser headless — pré-existentes e sem relação com a mudança.

## Outras mudanças

- `CUTSCENE_SKIP_HOLD_MS` exportado do `useCutscene` para quem precisar do mesmo tempo.

## Notas sobre deploy

Sem passo de deploy. Vale um olhar na revisão: a guarda de auto-repeat vale para o jogo inteiro, não só para cutscene.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint` nos 5 arquivos tocados → sem achados
- Playwright MCP (fluxos acima)

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
