### PR TITLE
feat: liberar o ataque carregado a partir do nv.15

### DIFF
--- a/src/data/battle/charge.ts
+++ b/src/data/battle/charge.ts
@@ -2,6 +2,9 @@ import { TWO_THOUSAND_MS } from "@/data/ms";
 
 export const CHARGE_TIME = TWO_THOUSAND_MS;
 
+/** Nível do personagem em uso a partir do qual o ataque carregado é liberado. */
+export const CHARGE_ATTACK_MIN_LEVEL = 15;
+
 export type ChargeParticle = {
   id: number;
   size: number;

--- a/src/hooks/battle/useScene.ts
+++ b/src/hooks/battle/useScene.ts
@@ -39,6 +39,7 @@ import { useComboSystem } from "@/hooks/battle/useComboSystem";
 import { useBattleRefs } from "@/hooks/battle/useRefs";
 import { useBattleKillCounter } from "@/hooks/battle/death/useKillCounter";
 import { useChargeAttack } from "@/hooks/battle/charge/useAttack";
+import { CHARGE_ATTACK_MIN_LEVEL } from "@/data/battle/charge";
 import { usePhaseTransition } from "@/hooks/battle/death/usePhaseTransition";
 import { useCoffinAnimation } from "@/hooks/battle/summon/useCoffinAnimation";
 import { usePlayerSpecialProjectile } from "@/hooks/battle/player/usePlayerSpecialProjectile";
@@ -1055,7 +1056,8 @@ export function useBattleScene({
     getSpecialFlowOverride(player.character) !== null;
 
   // Artur não usa o charge (segurar onConfirm = ORA ORA). Os demais mantêm.
-  const canCharge = player.character !== "artur";
+  const canCharge =
+    player.character !== "artur" && playerLevel >= CHARGE_ATTACK_MIN_LEVEL;
 
   const activateSpecial = useCallback(() => {
     if (freezeActionsUntilRef.current > Date.now()) return;


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Personagem abaixo do nv.15 perde o ataque carregado — quem já jogava com o gesto de segurar `L` volta a receber ataque normal até chegar lá.
> - A verificação em browser **não** ficou conclusiva (detalhe em Screenshots). Vale um teste manual de quem tem save avançado.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #189

## Problema

O ataque carregado estava disponível desde o nv.1. A issue define que ele é desbloqueio de progressão: "Todo personagem desbloqueia o ataque carregado ao alcançar o nv.15".

## Solução

O jogo já tinha o interruptor certo — `canCharge`, em `src/hooks/battle/useScene.ts`:

```ts
const canCharge = player.character !== "artur";
```

Quando ele é `false`, `useControls` não recebe `onChargePress`/`onChargeRelease`/`onChargeCancel`, `hasCharge` fica `false` e o `onConfirm` cai direto no ataque normal — caminho **já exercitado hoje** pelo `artur`, que tem mecânica de hold própria.

Bastou somar o nível ao mesmo interruptor:

```ts
const canCharge =
  player.character !== "artur" && playerLevel >= CHARGE_ATTACK_MIN_LEVEL;
```

`playerLevel` já existia no hook (`progress[player.character]?.level ?? 1`), então o gate é por **personagem em uso**, que é o que a issue pede — subir o Marcelo não libera o carregado da Larissa.

`CHARGE_ATTACK_MIN_LEVEL = 15` mora em `src/data/battle/charge.ts`, ao lado do `CHARGE_TIME`.

Conferido que o tutorial de combate não depende do carregado: `grep` por `charge` em `src/gameRules/tutorial/combatTasks.ts` e `src/hooks/tutorial/useCombatTasks.ts` não tem hit, então nenhuma tarefa fica impossível para o jogador nv.1.

## Screenshots

**Descrição do Screenshot**:
Não se aplica — e aqui vai o que **não** consegui provar, para não passar por verificado:

Tentei confirmar no browser com o Playwright MCP (batalha de encontro na biblioteca, e também `#/battle/tester/dummy`), inclusive editando o save para colocar o Marcelo no nv.15 e comparar. Não achei sinal observável do estado `charging` no DOM: as partículas de carga são `div` com estilo inline (sem classe que dê para casar) e o estado `charging` não troca o sprite do jogador. Segurar `L` pelo Playwright também não reproduz o hold do jeito que o jogo espera em toda tela.

O que está garantido: `tsc -b` e ESLint limpos, e o caminho `canCharge === false` não é novo — é o mesmo que o `artur` usa em produção hoje.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Sem passo de deploy, sem migração de save.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint src/hooks/battle/useScene.ts src/data/battle/charge.ts` → sem achados
- Playwright MCP → **inconclusivo**, conforme acima

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
