### PR TITLE
ref: memoizar o value do TombstoneContext

### DIFF
--- a/src/contexts/TombstoneContext.tsx
+++ b/src/contexts/TombstoneContext.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -160,16 +161,25 @@ export function TombstoneProvider({ children }: { children: ReactNode }) {
     [tombsByLocation, setTombsByLocation],
   );
 
+  const value = useMemo(
+    () => ({
+      prepareTombstoneSpawn,
+      clearPendingTombstoneSpawn,
+      spawnVictoryTombstone,
+      getTombstones,
+      collectTombstone,
+    }),
+    [
+      prepareTombstoneSpawn,
+      clearPendingTombstoneSpawn,
+      spawnVictoryTombstone,
+      getTombstones,
+      collectTombstone,
+    ],
+  );
+
   return (
-    <TombstoneContext.Provider
-      value={{
-        prepareTombstoneSpawn,
-        clearPendingTombstoneSpawn,
-        spawnVictoryTombstone,
-        getTombstones,
-        collectTombstone,
-      }}
-    >
+    <TombstoneContext.Provider value={value}>
       {children}
     </TombstoneContext.Provider>
   );


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - A issue foi escrita quando 21 de 23 providers passavam objeto inline. Levantando de novo na `main` de hoje, **sobrou um**: `TombstoneContext`. Este PR fecha ele e zera a contagem.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #44

## Problema

`TombstoneContext` era o último provider passando objeto novo a cada render:

```tsx
<TombstoneContext.Provider
  value={{ prepareTombstoneSpawn, clearPendingTombstoneSpawn, ... }}
>
```

Identidade nova a cada render invalida todo consumidor de `useTombstones()` e todo `useEffect`/`useMemo` que dependa de um método do contexto. Levantamento nos 24 arquivos de `src/contexts/` hoje:

```
value={{  →  1 arquivo (TombstoneContext)
useMemo   →  23 arquivos
```

## Solução

O caso é o "mecânico e de baixo risco" que a própria issue separa: **as cinco funções expostas já são `useCallback`** com dependências corretas (`prepareTombstoneSpawn` e `clearPendingTombstoneSpawn` com deps vazias, `spawnVictoryTombstone` em `[setTombsByLocation]`, `getTombstones` em `[tombsByLocation, fadingByLocation]`, `collectTombstone` em `[tombsByLocation, setTombsByLocation]`).

Ou seja: envolver o `value` num `useMemo` com essas cinco como dependências não muda quando o valor muda — só para de criar objeto novo quando **nenhuma** delas mudou. Sem `useCallback` novo, sem mexer em dependência de handler, sem o risco de stale closure que a issue usa para justificar não fazer isso em massa.

Depois deste PR, `grep -rn "value={{" src/contexts/*.tsx` retorna **0**.

## Screenshots

**Descrição do Screenshot**:
Não se aplica — refactor de identidade de objeto, sem efeito visual e sem mudança de comportamento.

## Outras mudanças

- Nenhuma.

## Notas sobre deploy

Sem passo de deploy. Não medi ganho com o Profiler: com as cinco funções já estáveis, o `useMemo` só elimina alocação de objeto — o ganho aqui é consistência (nenhum provider fora do padrão), não performance mensurável.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint src/contexts/TombstoneContext.tsx` → sem achados (inclusive `react-hooks/exhaustive-deps`)
- `grep -rn "value={{" src/contexts/*.tsx` → 0 ocorrências

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
