### PR TITLE
ref: consts para as mensagens de interação

### DIFF
--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -1,0 +1,84 @@
+/**
+ * Texto de interação exibido ao jogador.
+ *
+ * Mensagem repetida vive numa constante só: "Porta trancada" aparecia em seis
+ * arquivos de cena, e mudar o texto exigia caçar todas as cópias. O que muda
+ * com o contexto (nível exigido, item coletado) é função, não string solta.
+ */
+
+/** Rótulo do hint de interação, exibido acima do tile. */
+export const INTERACTION_LABELS = {
+  TALK: "[L] Conversar",
+  INTERACT: "[L] Interagir",
+  PICK_UP: "[L] Pegar",
+  COLLECT: "[L] Recolher",
+  OPEN: "[L] Abrir",
+  MINE: "[L] Minerar",
+  CHOP: "[L] Lenhar",
+} as const;
+
+/** Motivo pelo qual uma passagem não liberou. */
+export const BLOCKED_MESSAGES = {
+  LOCKED_DOOR: "Porta trancada",
+  BLOCKED_PASSAGE: "Passagem bloqueada",
+} as const;
+
+/** Popups de interação com cenário. */
+export const POPUP_MESSAGES = {
+  DOOR_LOCKED: "Essa porta está trancada.",
+  KEY_USED: "Você usou a chave.",
+  ROCK_ON_COOLDOWN: "A rocha ainda está se recuperando...",
+  ROCK_WITHOUT_ORE: "Esta rocha não contém minério conhecido.",
+  TREE_WITHOUT_WOOD: "Esta árvore não produz madeira conhecida.",
+  BOOK_SECRET_PASSAGE: "O livro revela uma passagem secreta!",
+  BOOK_ORDINARY: "Um livro empoeirado. Nada de especial.",
+} as const;
+
+/** Ferramenta que falta para a ação de profissão. */
+export const TOOL_REQUIRED_MESSAGES = {
+  PICKAXE: "Você precisa equipar uma picareta para minerar.",
+  AXE: "Você precisa equipar um machado para lenhar.",
+} as const;
+
+/**
+ * Mensagem de nível insuficiente numa ação de profissão.
+ *
+ * Args:
+ *     profession (string): nome da profissão exigida.
+ *     requiredLevel (number): nível mínimo do recurso.
+ *     currentLevel (number): nível atual do jogador na profissão.
+ *     action (string): o que ele tentou fazer, com o alvo.
+ *
+ * Returns:
+ *     O texto pronto para o popup.
+ */
+export function professionLevelRequired(
+  profession: string,
+  requiredLevel: number,
+  currentLevel: number,
+  action: string,
+): string {
+  return `Você precisa ser ${profession} nv.${requiredLevel} para ${action}. (você é nv.${currentLevel})`;
+}
+
+/**
+ * Resumo de uma coleta de profissão.
+ *
+ * Args:
+ *     action (string): frase da ação concluída, já com o alvo.
+ *     summary (string): itens obtidos, formatados.
+ *     xpGained (number): XP ganho na interação.
+ *     profession (string): nome da profissão que recebeu o XP.
+ *
+ * Returns:
+ *     O texto pronto para o popup, sem a nota de XP quando ele é zero.
+ */
+export function gatherResult(
+  action: string,
+  summary: string,
+  xpGained: number,
+  profession: string,
+): string {
+  const xpNote = xpGained > 0 ? ` (+${xpGained} XP de ${profession})` : "";
+  return `${action} Obteve: ${summary}.${xpNote}`;
+}

--- a/src/features/cafeteria/index.tsx
+++ b/src/features/cafeteria/index.tsx
@@ -15,6 +15,7 @@ import { useContainer } from "@/hooks/container/useContainer";
 
 import { Container } from "@/components/Game/Map/Container";
 import Talking from "@/components/Game/Interactions/Talking";
+import { INTERACTION_LABELS } from "@/data/messages";
 
 type Props = {
   sceneId: SceneId;
@@ -85,7 +86,7 @@ export function CafeteriaScene({ sceneId }: Props) {
         scene={scene}
         background={scene.background}
         interactions={interactions}
-        interactionLabels={{ "15,4": "[L] Abrir" }}
+        interactionLabels={{ "15,4": INTERACTION_LABELS.OPEN }}
         popup={popup}
         setPopup={setPopup}
       />

--- a/src/features/hall/index.tsx
+++ b/src/features/hall/index.tsx
@@ -6,6 +6,7 @@ import { PandemonyPuzzle } from "@/components/Game/Map/PandemonyPuzzle";
 import { useInventory } from "@/contexts/InventoryContext";
 import { useQuests } from "@/contexts/QuestContext";
 import Talking from "@/components/Game/Interactions/Talking";
+import { BLOCKED_MESSAGES } from "@/data/messages";
 
 type Props = {
   sceneId: SceneId;
@@ -29,7 +30,7 @@ export function HallScene({ sceneId }: Props) {
         if (hasPandemony) {
           setShowPuzzle(true);
         } else {
-          setPopup("Porta trancada");
+          setPopup(BLOCKED_MESSAGES.LOCKED_DOOR);
         }
         return true;
       }

--- a/src/features/jomasioEntrance/index.tsx
+++ b/src/features/jomasioEntrance/index.tsx
@@ -39,6 +39,13 @@ import { rollMineGather } from "@/gameRules/professions/mine";
 import { rollProfessionMaterial } from "@/gameRules/professions/weapon";
 import { rockGridKey, toRockTiles } from "@/gameRules/movement/rocks";
 import { THREE_THOUSAND_MS } from "@/data/ms";
+import {
+  INTERACTION_LABELS,
+  POPUP_MESSAGES,
+  TOOL_REQUIRED_MESSAGES,
+  gatherResult,
+  professionLevelRequired,
+} from "@/data/messages";
 
 type Props = {
   sceneId: SceneId;
@@ -49,7 +56,7 @@ const MINE_COOLDOWN_MS = THREE_THOUSAND_MS;
 const ROCK_TILES = toRockTiles(jomasioEntranceRocks);
 
 const ROCK_LABELS = Object.fromEntries(
-  jomasioEntranceRocks.map((rock) => [rockGridKey(rock), "[L] Minerar"]),
+  jomasioEntranceRocks.map((rock) => [rockGridKey(rock), INTERACTION_LABELS.MINE]),
 );
 
 type MineRockDeps = ToolDeps & {
@@ -86,10 +93,10 @@ export function JomasioEntranceScene({ sceneId }: Props) {
     const mineRock = (rockLevel: number) =>
       createToolInteraction<MineRockDeps>(
         "weapon_pickaxe",
-        "Você precisa equipar uma picareta para minerar.",
+        TOOL_REQUIRED_MESSAGES.PICKAXE,
         (deps) => {
           if (Date.now() - lastMineTimeRef.current < MINE_COOLDOWN_MS) {
-            deps.setPopup("A rocha ainda está se recuperando...");
+            deps.setPopup(POPUP_MESSAGES.ROCK_ON_COOLDOWN);
             return;
           }
           lastMineTimeRef.current = Date.now();
@@ -98,13 +105,18 @@ export function JomasioEntranceScene({ sceneId }: Props) {
 
           const ores = getOresByRockLevel(rockLevel);
           if (ores.length === 0) {
-            deps.setPopup("Esta rocha não contém minério conhecido.");
+            deps.setPopup(POPUP_MESSAGES.ROCK_WITHOUT_ORE);
             return;
           }
 
           if (level < rockLevel) {
             deps.setPopup(
-              `Você precisa ser Mineiro nv.${rockLevel} para minerar esta rocha. (você é nv.${level})`,
+              professionLevelRequired(
+                "Mineiro",
+                rockLevel,
+                level,
+                "minerar esta rocha",
+              ),
             );
             return;
           }
@@ -128,8 +140,14 @@ export function JomasioEntranceScene({ sceneId }: Props) {
             .join(", ");
 
           const xpGained = result?.xpGained ?? 0;
-          const xpNote = xpGained > 0 ? ` (+${xpGained} XP de Mineiro)` : "";
-          deps.setPopup(`Você minerou a rocha! Obteve: ${summary}.${xpNote}`);
+          deps.setPopup(
+            gatherResult(
+              "Você minerou a rocha!",
+              summary,
+              xpGained,
+              "Mineiro",
+            ),
+          );
 
           if (xpGained > 0) {
             deps.addProficiencyXP(deps.character, "miner", xpGained);
@@ -140,19 +158,24 @@ export function JomasioEntranceScene({ sceneId }: Props) {
     const chopWood = (treeLevel: number) =>
       createToolInteraction<MineRockDeps>(
         "weapon_axe",
-        "Você precisa equipar um machado para lenhar.",
+        TOOL_REQUIRED_MESSAGES.AXE,
         (deps) => {
           const { level } = deps.getProficiency(deps.character, "lumberjack");
 
           const wood = getWoodLevelByTreeLevel(treeLevel);
           if (!wood) {
-            deps.setPopup("Esta árvore não produz madeira conhecida.");
+            deps.setPopup(POPUP_MESSAGES.TREE_WITHOUT_WOOD);
             return;
           }
 
           if (level < wood.treeLevel) {
             deps.setPopup(
-              `Você precisa ser Lenhador nv.${wood.treeLevel} para lenhar esta árvore. (você é nv.${level})`,
+              professionLevelRequired(
+                "Lenhador",
+                wood.treeLevel,
+                level,
+                "lenhar esta árvore",
+              ),
             );
             return;
           }
@@ -174,8 +197,14 @@ export function JomasioEntranceScene({ sceneId }: Props) {
             )
             .join(", ");
 
-          const xpNote = xpGained > 0 ? ` (+${xpGained} XP de Lenhador)` : "";
-          deps.setPopup(`Você lenhou a árvore! Obteve: ${summary}.${xpNote}`);
+          deps.setPopup(
+            gatherResult(
+              "Você lenhou a árvore!",
+              summary,
+              xpGained,
+              "Lenhador",
+            ),
+          );
 
           if (xpGained > 0) {
             deps.addProficiencyXP(deps.character, "lumberjack", xpGained);
@@ -235,7 +264,7 @@ export function JomasioEntranceScene({ sceneId }: Props) {
         interactions={interactions}
         interactionLabels={{
           ...ROCK_LABELS,
-          "5,7": "[L] Lenhar",
+          "5,7": INTERACTION_LABELS.CHOP,
         }}
         itemPickupTiles={ROCK_TILES}
         popup={popup}

--- a/src/hooks/scene/useSceneLayers.ts
+++ b/src/hooks/scene/useSceneLayers.ts
@@ -4,6 +4,7 @@ import { isNpcInFront } from "@/utils/isNpcInFront";
 import { isPositionInFront, parseGridKey } from "@/utils/isPositionInFront";
 import { canStepTo } from "@/gameRules/movement/levels";
 import type { ItemPickupTile } from "@/utils/types/maps/exploreScene";
+import { INTERACTION_LABELS } from "@/data/messages";
 
 type Player = {
   gridX: number;
@@ -66,31 +67,31 @@ export function useSceneLayers({
     if (!canStepTo(player.height, heightMap, x, y)) return null;
 
     const npc = npcs.find((n) => isNpcInFront(player, n));
-    if (npc) return "[L] Conversar";
+    if (npc) return INTERACTION_LABELS.TALK;
 
     const hasInteractionKey = interactionKeys?.some((key) => {
       const pos = parseGridKey(key);
       return pos ? isPositionInFront(player, pos.x, pos.y) : false;
     });
     if (hasInteractionKey) {
-      return interactionLabels?.[`${x},${y}`] ?? "[L] Interagir";
+      return interactionLabels?.[`${x},${y}`] ?? INTERACTION_LABELS.INTERACT;
     }
 
     const pickup = itemPickupTiles?.find(
       (t) => t.visible && isPositionInFront(player, t.x, t.y),
     );
-    if (pickup) return "[L] Pegar";
+    if (pickup) return INTERACTION_LABELS.PICK_UP;
 
-    if (tileDialogues?.[`${x},${y}`]) return "[L] Interagir";
+    if (tileDialogues?.[`${x},${y}`]) return INTERACTION_LABELS.INTERACT;
 
     const tombstone = tombstones?.find((t) => t.x === x && t.y === y);
-    if (tombstone) return "[L] Recolher";
+    if (tombstone) return INTERACTION_LABELS.COLLECT;
 
     const groundLoot = groundLoots?.find((l) => l.x === x && l.y === y);
-    if (groundLoot) return "[L] Pegar";
+    if (groundLoot) return INTERACTION_LABELS.PICK_UP;
 
     const plate = plates.find((p) => p.gridX === x && p.gridY === y);
-    if (plate) return "[L] Interagir";
+    if (plate) return INTERACTION_LABELS.INTERACT;
 
     return null;
   }, [

--- a/src/interactions/director.ts
+++ b/src/interactions/director.ts
@@ -6,6 +6,7 @@ import type {
   QuestDeps,
   ImageDeps,
 } from "@/utils/types/interaction";
+import { POPUP_MESSAGES } from "@/data/messages";
 
 type DirectorDeps = PickupDeps &
   InventoryDeps &
@@ -26,7 +27,7 @@ export function createDirector(deps: DirectorDeps) {
 
     "4,2": ({ hasItem, setPopup, navigate, playSFX }) => {
       if (hasItem("director_key")) {
-        setPopup("Você usou a chave.");
+        setPopup(POPUP_MESSAGES.KEY_USED);
         progressQuest("director_escape", 1);
         playSFX?.("/assets/songs/transitions/doorOpen.mp3", 0.6);
 
@@ -35,7 +36,7 @@ export function createDirector(deps: DirectorDeps) {
           navigate?.("/cantina/one");
         }, 1000);
       } else {
-        setPopup("Essa porta está trancada.");
+        setPopup(POPUP_MESSAGES.DOOR_LOCKED);
       }
     },
 

--- a/src/interactions/library.ts
+++ b/src/interactions/library.ts
@@ -3,6 +3,7 @@ import { createInteractionMap, createPickupHandler } from "./builder";
 import type { PickupDeps } from "@/utils/types/interaction";
 import { hasQuest } from "@/scenes/shared/helpers";
 import { LIBRARY_ROUTES } from "@/scenes/shared/routes";
+import { POPUP_MESSAGES } from "@/data/messages";
 
 type LibraryDeps = Omit<PickupDeps, "gotKey" | "setFlag"> & {
   quests: { id: string }[];
@@ -34,11 +35,11 @@ export function createLibrary(deps: LibraryDeps) {
 
   messages["14,2"] = () => {
     if (hasQuest(deps.quests, "save_ematron")) {
-      deps.setPopup("O livro revela uma passagem secreta!");
+      deps.setPopup(POPUP_MESSAGES.BOOK_SECRET_PASSAGE);
       deps.navigate?.(LIBRARY_ROUTES.TWO);
       return;
     }
-    deps.setPopup("Um livro empoeirado. Nada de especial.");
+    deps.setPopup(POPUP_MESSAGES.BOOK_ORDINARY);
   };
 
   return messages;

--- a/src/scenes/cantina/one/tiles.ts
+++ b/src/scenes/cantina/one/tiles.ts
@@ -5,6 +5,7 @@ import {
   CAFETERIA_ROUTES,
 } from "@/scenes/shared/routes";
 import { hasQuest } from "@/scenes/shared/helpers";
+import { BLOCKED_MESSAGES } from "@/data/messages";
 
 export const cantinaOneTiles = [
   createConditionalTile(
@@ -17,7 +18,7 @@ export const cantinaOneTiles = [
       return null;
     },
     {
-      blockedMessage: "Passagem bloqueada",
+      blockedMessage: BLOCKED_MESSAGES.BLOCKED_PASSAGE,
     },
   ),
   createConditionalTile(
@@ -30,7 +31,7 @@ export const cantinaOneTiles = [
       return null;
     },
     {
-      blockedMessage: "Passagem bloqueada",
+      blockedMessage: BLOCKED_MESSAGES.BLOCKED_PASSAGE,
     },
   ),
   createConditionalTile(
@@ -43,7 +44,7 @@ export const cantinaOneTiles = [
       return null;
     },
     {
-      blockedMessage: "Porta trancada",
+      blockedMessage: BLOCKED_MESSAGES.LOCKED_DOOR,
     },
   ),
   createConditionalTile(
@@ -58,7 +59,7 @@ export const cantinaOneTiles = [
       return null;
     },
     {
-      blockedMessage: "Porta trancada",
+      blockedMessage: BLOCKED_MESSAGES.LOCKED_DOOR,
     },
   ),
 ];

--- a/src/scenes/cantina/two/tiles.ts
+++ b/src/scenes/cantina/two/tiles.ts
@@ -8,6 +8,7 @@ import {
   CAFETERIA_ROUTES,
 } from "@/scenes/shared/routes";
 import { hasAnyQuest, hasQuest } from "@/scenes/shared/helpers";
+import { BLOCKED_MESSAGES } from "@/data/messages";
 
 export const cantinaTwoTiles = [
   createDoorTile(2, 2, HALL_ROUTES.CENTER_ONE),
@@ -21,7 +22,7 @@ export const cantinaTwoTiles = [
       return null;
     },
     {
-      blockedMessage: "Porta trancada",
+      blockedMessage: BLOCKED_MESSAGES.LOCKED_DOOR,
     },
   ),
   createConditionalTile(
@@ -36,7 +37,7 @@ export const cantinaTwoTiles = [
       return null;
     },
     {
-      blockedMessage: "Porta trancada",
+      blockedMessage: BLOCKED_MESSAGES.LOCKED_DOOR,
     },
   ),
   createConditionalTile(17, 12, (_player, quests) => {

--- a/src/scenes/hall/hell/tiles.ts
+++ b/src/scenes/hall/hell/tiles.ts
@@ -4,6 +4,7 @@ import {
 } from "@/scenes/shared/factories";
 import { HALL_ROUTES, HELLROOM_ROUTES } from "@/scenes/shared/routes";
 import { hasQuest } from "@/scenes/shared/helpers";
+import { BLOCKED_MESSAGES } from "@/data/messages";
 
 export const hellTiles = [
   createDoorTile(8, 12, HALL_ROUTES.CENTER_ONE),
@@ -22,7 +23,7 @@ export const hellTiles = [
       return null;
     },
     {
-      blockedMessage: "Porta trancada",
+      blockedMessage: BLOCKED_MESSAGES.LOCKED_DOOR,
     },
   ),
   createConditionalTile(

--- a/src/scenes/hellroom/two/tiles.ts
+++ b/src/scenes/hellroom/two/tiles.ts
@@ -1,6 +1,7 @@
 import { createConditionalTile } from "@/scenes/shared/factories";
 import { HALL_ROUTES } from "@/scenes/shared/routes";
 import { hasFlag } from "@/scenes/shared/helpers";
+import { BLOCKED_MESSAGES } from "@/data/messages";
 
 export const hellRoomTwoTiles = [
   createConditionalTile(
@@ -13,7 +14,7 @@ export const hellRoomTwoTiles = [
       return null;
     },
     {
-      blockedMessage: "Porta trancada",
+      blockedMessage: BLOCKED_MESSAGES.LOCKED_DOOR,
     },
   ),
 ];


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - Refactor sem mudança de comportamento: todo texto continua idêntico, letra por letra.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #22

## Problema

Mensagem de interação era string solta no meio da cena e do feature. O custo aparece na repetição: **"Porta trancada" estava escrito em seis lugares** (`cantina/one`, `cantina/two` ×2, `hellroom/two`, `hall/hell`, `features/hall`), "Passagem bloqueada" em dois, `[L] Interagir` em três. Trocar um texto significava caçar todas as cópias, e uma cópia esquecida é uma cena falando diferente das outras.

## Solução

`src/data/messages.ts` agrupa por finalidade:

- `INTERACTION_LABELS` — hint acima do tile (`[L] Minerar`, `[L] Conversar`, …)
- `BLOCKED_MESSAGES` — motivo de passagem bloqueada
- `POPUP_MESSAGES` — popups de cenário (livro, rocha, porta)
- `TOOL_REQUIRED_MESSAGES` — ferramenta que falta para a ação de profissão

O que varia com o contexto virou função, não string montada no call site:

- `professionLevelRequired(profissão, nívelExigido, nívelAtual, ação)`
- `gatherResult(ação, resumo, xp, profissão)` — inclusive a regra de "só mostra a nota de XP quando ele é > 0", que estava duplicada no minerar e no lenhar.

Depois deste PR, `grep -rn '"\[L\] \|blockedMessage: "\|setPopup("' src` (fora do módulo novo) retorna **0**.

## Screenshots

**Descrição do Screenshot**:
Validado com o Playwright MCP na `/jomasioentrance/one`, andando até a rocha grande e interagindo:

```
hint : ◉ | [L] Minerar | B | L
popup: ◉ | [L] Minerar | Sistema | Você precisa equipar uma picareta para minerar. | B | L
```

Cobre os dois caminhos refatorados naquela tela: `INTERACTION_LABELS.MINE` no hint e `TOOL_REQUIRED_MESSAGES.PICKAXE` no popup, com o texto igual ao de antes.

## Outras mudanças

- Nenhuma. Nenhum texto foi reescrito — só movido.

## Notas sobre deploy

Sem passo de deploy. Base pronta para i18n (#58): o texto agora está num módulo só, em vez de espalhado por cena.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint` nos arquivos tocados → sem achados
- Playwright MCP (saída acima)

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
