### PR TITLE
ref: fonte única para o grid e a largura da área de jogo

### DIFF
--- a/src/components/Game/Map/Menu/styles.module.css
+++ b/src/components/Game/Map/Menu/styles.module.css
@@ -1,7 +1,7 @@
 .mapOverlay {
   position: fixed;
   top: 0;
-  width: 74vw;
+  width: var(--game-viewport-width);
   height: 100%;
   display: flex;
   justify-content: center;

--- a/src/components/Game/Navbar/ExploreNavbar/Config/styles.module.css
+++ b/src/components/Game/Navbar/ExploreNavbar/Config/styles.module.css
@@ -4,7 +4,7 @@
   top: 5%;
   right: 0;
   gap: 3vw;
-  width: calc(74vw - var(--size-6));
+  width: calc(var(--game-viewport-width) - var(--size-6));
   height: 90vh;
   align-items: flex-start;
   justify-content: center;

--- a/src/components/Game/Scenes/Battle/index.tsx
+++ b/src/components/Game/Scenes/Battle/index.tsx
@@ -32,6 +32,7 @@ import { ProjectileConstants } from "@/data/projectile";
 import { BATTLE_SPAWN } from "@/gameRules/battle/spawnPoints";
 import { getBossSizeMultiplier } from "@/utils/npc/getSpritePath";
 import { npcPath } from "@/utils/paths";
+import { GAME_VIEWPORT_WIDTH_RATIO } from "@/data/grid";
 
 type Props = {
   npcType: string;
@@ -114,7 +115,7 @@ export function BattleScene(props: Props) {
 
   const { setBattleCollision } = usePlayerActions();
 
-  const containerWidth = window.innerWidth * 0.74;
+  const containerWidth = window.innerWidth * GAME_VIEWPORT_WIDTH_RATIO;
   const containerHeight = window.innerHeight;
 
   const initialBgPosRef = useRef({

--- a/src/data/grid.ts
+++ b/src/data/grid.ts
@@ -1,0 +1,34 @@
+/**
+ * Medidas do grid de cena e da área de jogo.
+ *
+ * Fonte única: o número aparecia repetido em hook, regra e CSS — `17`/`13`
+ * como fallback do layout e de novo no spawn de lápide, e `0.74` em três
+ * arquivos TS mais oito de CSS como `74vw`. Mudar a proporção da área de jogo
+ * exigia achar todas as cópias, e uma esquecida deixa a tela desalinhada.
+ */
+
+/** Colunas do grid quando a cena não declara mapa próprio. */
+export const MAP_GRID_COLS = 17;
+
+/** Linhas do grid quando a cena não declara mapa próprio. */
+export const MAP_GRID_ROWS = 13;
+
+/** Fração da largura da janela ocupada pela área de jogo. */
+export const GAME_VIEWPORT_WIDTH_RATIO = 0.74;
+
+/** Nome da custom property que leva a largura da área de jogo para o CSS. */
+export const GAME_VIEWPORT_WIDTH_VAR = "--game-viewport-width";
+
+/**
+ * Publica a largura da área de jogo como custom property no `:root`.
+ *
+ * CSS não importa constante de TS, então os `74vw` espalhados pelas folhas
+ * eram cópia manual de `GAME_VIEWPORT_WIDTH_RATIO`. Escrever a variável no
+ * boot inverte a dependência: o valor sai daqui e o CSS só consome.
+ */
+export function applyGameViewportWidth(root: HTMLElement): void {
+  root.style.setProperty(
+    GAME_VIEWPORT_WIDTH_VAR,
+    `${GAME_VIEWPORT_WIDTH_RATIO * 100}vw`,
+  );
+}

--- a/src/features/pcRoom/styles.module.css
+++ b/src/features/pcRoom/styles.module.css
@@ -1,6 +1,6 @@
 .classModal {
   flex-direction: column;
-  width: 74vw;
+  width: var(--game-viewport-width);
 }
 
 .classList {

--- a/src/gameRules/tombstone/tombstone.ts
+++ b/src/gameRules/tombstone/tombstone.ts
@@ -1,5 +1,6 @@
 import { npcPath } from "@/utils/paths";
 import { isNpcType } from "@/data/npc/npc";
+import { MAP_GRID_COLS, MAP_GRID_ROWS } from "@/data/grid";
 import { ONE_THOUSAND_MS } from "@/data/ms";
 import type {
   Tombstone,
@@ -9,8 +10,7 @@ import type {
 
 export const TOMBSTONE_FADE_MS = ONE_THOUSAND_MS;
 
-export const MAP_GRID_COLS = 17;
-export const MAP_GRID_ROWS = 13;
+
 
 /**
  * A lápide nasce no tile em frente ao jogador (onde o NPC estava):

--- a/src/hooks/game/useGameLayout.ts
+++ b/src/hooks/game/useGameLayout.ts
@@ -1,10 +1,15 @@
 import { usePlayer } from "@/contexts/PlayerContext";
 import { useState, useEffect, useRef } from "react";
 import { HEIGHT_STEP_OFFSET } from "@/gameRules/movement/levels";
+import {
+  GAME_VIEWPORT_WIDTH_RATIO,
+  MAP_GRID_COLS,
+  MAP_GRID_ROWS,
+} from "@/data/grid";
 
 export function useGameLayout(map?: number[][], scaleFix = 3) {
-  const MAP_COLS = map?.[0]?.length ?? 17;
-  const MAP_ROWS = map?.length ?? 13;
+  const MAP_COLS = map?.[0]?.length ?? MAP_GRID_COLS;
+  const MAP_ROWS = map?.length ?? MAP_GRID_ROWS;
   const CAMERA_SMOOTHING = 0.3;
 
   const { player } = usePlayer();
@@ -22,7 +27,7 @@ export function useGameLayout(map?: number[][], scaleFix = 3) {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  const containerWidth = dimensions.width * 0.74;
+  const containerWidth = dimensions.width * GAME_VIEWPORT_WIDTH_RATIO;
   const containerHeight = dimensions.height;
 
   const TILE_SIZE =

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,10 +6,13 @@ import "./styles/index.css";
 
 import { AppProviders } from "@/contexts/AppProviders";
 import { AppRoutes } from "@/pages/AppRoutes";
+import { applyGameViewportWidth } from "@/data/grid";
 
 type ContainerWithRoot = HTMLElement & {
   _reactRoot: ReturnType<typeof createRoot>;
 };
+
+applyGameViewportWidth(document.documentElement);
 
 const container = document.getElementById("root")!;
 const root =

--- a/src/pages/Loading/styles.module.css
+++ b/src/pages/Loading/styles.module.css
@@ -1,6 +1,6 @@
 .screen {
   position: fixed;
-  width: 74vw;
+  width: var(--game-viewport-width);
   height: 100dvh;
   background-size: cover;
   background-position: center;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -18,7 +18,7 @@
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  width: 74vw;
+  width: var(--game-viewport-width);
   height: 100dvh;
   overflow: hidden;
   pointer-events: none;
@@ -40,7 +40,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 74vw;
+  width: var(--game-viewport-width);
   height: 100dvh;
   background-size: cover;
   background-repeat: no-repeat;
@@ -52,7 +52,7 @@
   top: 5%;
   right: 0;
   flex-direction: column;
-  width: calc(74vw - var(--size-6));
+  width: calc(var(--game-viewport-width) - var(--size-6));
   height: 90dvh;
   background: linear-gradient(
     170deg,

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -2,7 +2,7 @@
   display: flex;
   position: fixed;
   top: 0;
-  width: 74vw;
+  width: var(--game-viewport-width);
   height: 100%;
   background: rgba(0, 0, 0, 0.7);
   align-self: center;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,4 +1,6 @@
 :root {
+  /* Sobrescrita em runtime por applyGameViewportWidth (src/data/grid.ts). */
+  --game-viewport-width: 74vw;
   --primary-color: #121b31;
   --secondary-color: #fbbf24;
   --background-color: #0a0500;

--- a/src/utils/replay/replayLayout.ts
+++ b/src/utils/replay/replayLayout.ts
@@ -1,3 +1,4 @@
+import { GAME_VIEWPORT_WIDTH_RATIO } from "@/data/grid";
 import { ProjectileConstants } from "@/data/projectile";
 
 const MAP_COLS = 17;
@@ -5,7 +6,7 @@ const MAP_ROWS = 13;
 const SCALE_FIX = 1.4;
 
 export function getReplayLayout(w: number, h: number) {
-  const cw = w * 0.74;
+  const cw = w * GAME_VIEWPORT_WIDTH_RATIO;
   const ch = h;
 
   const TILE = Math.min(cw / MAP_COLS, ch / MAP_ROWS) * SCALE_FIX;


### PR DESCRIPTION
Tem Script? | Novas Env Vars
-- | --
Não | Não

> :warning: **NOTA**
> - A largura da área de jogo passa a ser publicada em runtime como custom property (`--game-viewport-width`) por `src/main.tsx`. O CSS mantém `74vw` como fallback no `:root`, então nada quebra se o JS não tiver rodado ainda.
> - O `tsc -b` só fica verde com o #198 mergeado (TS2459 pré-existente na `main`).

Closes #21

## Problema

Dois números do grid estavam copiados por todo lado, e mudar um exigia caçar todas as cópias — exatamente o "eu mudo a const e ajusta tudo" que a issue pede:

| Valor | Onde estava repetido |
| --- | --- |
| `17` / `13` (grid padrão) | `useGameLayout.ts` (fallback) e `gameRules/tombstone/tombstone.ts` (`MAP_GRID_COLS`/`MAP_GRID_ROWS`) |
| `0.74` (largura da área de jogo) | `useGameLayout.ts`, `Scenes/Battle/index.tsx`, `utils/replay/replayLayout.ts` |
| `74vw` (o mesmo 0.74, em CSS) | 8 ocorrências em 6 arquivos |

Ou seja, a mesma proporção escrita de duas formas em 11 lugares. Mexer em uma e esquecer outra desalinha a área de jogo do resto da tela.

## Solução

`src/data/grid.ts` como fonte única: `MAP_GRID_COLS`, `MAP_GRID_ROWS`, `GAME_VIEWPORT_WIDTH_RATIO`.

Os três arquivos TS passam a multiplicar por `GAME_VIEWPORT_WIDTH_RATIO`, e `tombstone.ts` importa o grid em vez de declarar o próprio par de constantes.

Para o CSS — que não importa constante de TS — a dependência foi invertida em vez de duplicada:

```ts
export function applyGameViewportWidth(root: HTMLElement): void {
  root.style.setProperty(
    GAME_VIEWPORT_WIDTH_VAR,
    `${GAME_VIEWPORT_WIDTH_RATIO * 100}vw`,
  );
}
```

Chamada uma vez no `main.tsx`, antes do render. As 8 ocorrências de `74vw` viraram `var(--game-viewport-width)`, e o `:root` guarda `74vw` só como fallback comentado, apontando para o módulo dono do valor.

Depois deste PR, `grep -rn "0.74" src --include=*.ts --include=*.tsx` fora do `data/grid.ts` retorna **0**, e o único `74vw` restante é o fallback do `:root`.

## Screenshots

**Descrição do Screenshot**:
Validado com o Playwright MCP na `/library/one` (1280×800): layout idêntico ao de antes — mesma área de jogo centralizada, mesmo chrome. Medição na página:

```
--game-viewport-width (computado): 74vw
--game-viewport-width (inline no <html>): 74vw   ← escrito por applyGameViewportWidth
innerWidth: 1280 | 74% = 947.2
```

A variável chega ao `:root` pelo caminho novo, e o valor bate com o que o hook usa em JS.

## Outras mudanças

- `MAP_GRID_COLS`/`MAP_GRID_ROWS` saem de `gameRules/tombstone/tombstone.ts` — o lugar delas não era a regra de lápide.

## Notas sobre deploy

Sem passo de deploy. Mudar a proporção da área de jogo agora é uma linha em `src/data/grid.ts`.

**Validação local executada**:
- `npm run type-check` → só o TS2459 pré-existente da `main` (#198)
- `npx eslint` nos arquivos TS tocados → sem achados
- Playwright MCP (medição acima)

**Novas Variáveis de Ambiente**:
- Nenhuma

**Novos Scripts e/ou Tarefas de Background**:
- Nenhum

**Novas Dependências**:
- Nenhuma
